### PR TITLE
Version 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ language: php
 php:
   - 7.0
   - 7.1
-  - nightly
-
-matrix:
-  allow_failures:
-    - php: nightly
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
+# Version 1.0.2 2017-09-28 - Thanks phpstan!
+- After using `phpstan/phpstan` change the execution plan on `CadenaOrigen`.
+  The function previous function `throwLibXmlErrorOrMessage(string $message)` always
+  throw an exception but it was not clear in the flow of `build` method.
+  Now it returns a \RuntimeException and that is thrown. So it is easy for an analysis tool
+  to know that the flow has been stopped. 
+- Also fix case of calls `XSLTProcessor::importStylesheet` and `XSLTProcessor::transformToXml`
+- Check with `isset` that LibXMLError::$message exists, phpstan was failing for this.
+
+
 # Version 1.0.1 2017-09-27
 - Remove Travis CI PHP nightly builds, it fail with require-dev dependencies.
+
 
 # Version 1.0.0 2017-09-27
 - Initial release

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,2 +1,5 @@
+# Version 1.0.1 2017-09-27
+- Remove Travis CI PHP nightly builds, it fail with require-dev dependencies.
+
 # Version 1.0.0 2017-09-27
 - Initial release

--- a/src/CfdiUtils/CadenaOrigen.php
+++ b/src/CfdiUtils/CadenaOrigen.php
@@ -83,7 +83,7 @@ class CadenaOrigen
     private function throwLibXmlErrorOrMessage(string $message)
     {
         $error = libxml_get_last_error();
-        if ($error instanceof LibXMLError) {
+        if (($error instanceof LibXMLError) && isset($error->message)) {
             $message = $message . ': ' . $error->message;
         }
         throw new \RuntimeException($message);

--- a/src/CfdiUtils/CadenaOrigen.php
+++ b/src/CfdiUtils/CadenaOrigen.php
@@ -65,12 +65,10 @@ class CadenaOrigen
             }
 
             $xslt = new XSLTProcessor();
-            if (! $xslt->importStyleSheet($xsl)) {
                 $this->throwLibXmlErrorOrMessage('Error while importing the style sheet from the Xslt location');
             }
 
             // this error silenced call is intentional, avoid transformation errors except when return false
-            $transform = @$xslt->transformToXML($cfdi);
             if (false === $transform || null === $transform) {
                 $this->throwLibXmlErrorOrMessage('Error while transforming the xslt content');
             }

--- a/src/CfdiUtils/CadenaOrigen.php
+++ b/src/CfdiUtils/CadenaOrigen.php
@@ -47,7 +47,7 @@ class CadenaOrigen
             // load the cfdi document
             $cfdi = new DOMDocument();
             if (! $cfdi->loadXML($cfdiContent)) {
-                $this->throwLibXmlErrorOrMessage('Error while loading the cfdi content');
+                throw $this->createLibXmlErrorOrMessage('Error while loading the cfdi content');
             }
 
             // if not set, obtain default location from document version
@@ -61,16 +61,18 @@ class CadenaOrigen
 
             $xsl = new DOMDocument();
             if (! $xsl->load($xsltLocation)) {
-                $this->throwLibXmlErrorOrMessage('Error while loading the Xslt location');
+                throw $this->createLibXmlErrorOrMessage('Error while loading the Xslt location');
             }
 
             $xslt = new XSLTProcessor();
-                $this->throwLibXmlErrorOrMessage('Error while importing the style sheet from the Xslt location');
+            if (! $xslt->importStylesheet($xsl)) {
+                throw $this->createLibXmlErrorOrMessage('Error while importing the style sheet from the Xslt location');
             }
 
             // this error silenced call is intentional, avoid transformation errors except when return false
+            $transform = @$xslt->transformToXml($cfdi);
             if (false === $transform || null === $transform) {
-                $this->throwLibXmlErrorOrMessage('Error while transforming the xslt content');
+                throw $this->createLibXmlErrorOrMessage('Error while transforming the xslt content');
             }
 
             return $transform;
@@ -80,12 +82,12 @@ class CadenaOrigen
         }
     }
 
-    private function throwLibXmlErrorOrMessage(string $message)
+    private function createLibXmlErrorOrMessage(string $message): \Exception
     {
         $error = libxml_get_last_error();
         if (($error instanceof LibXMLError) && isset($error->message)) {
             $message = $message . ': ' . $error->message;
         }
-        throw new \RuntimeException($message);
+        return new \RuntimeException($message);
     }
 }


### PR DESCRIPTION
- After using `phpstan/phpstan` change the execution plan on `CadenaOrigen`.
  The function previous function `throwLibXmlErrorOrMessage(string $message)` always
  throw an exception but it was not clear in the flow of `build` method.
  Now it returns a \RuntimeException and that is thrown. So it is easy for an analysis tool
  to know that the flow has been stopped. 
- Also fix case of calls `XSLTProcessor::importStylesheet` and `XSLTProcessor::transformToXml`
- Check with `isset` that `LibXMLError::$message` exists, phpstan was failing for this.
