### PR TITLE
Add method to string and fix attribute name

### DIFF
--- a/src/CfdiUtils/CfdiCreator33.php
+++ b/src/CfdiUtils/CfdiCreator33.php
@@ -161,4 +161,16 @@ class CfdiCreator33 implements
 
         return $asserts;
     }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        try {
+            return $this->asXml();
+        } catch (\Throwable $ex) {
+            return '';
+        }
+    }
 }

--- a/src/CfdiUtils/Elements/ImpLocal10/ImpuestosLocales.php
+++ b/src/CfdiUtils/Elements/ImpLocal10/ImpuestosLocales.php
@@ -35,7 +35,7 @@ class ImpuestosLocales extends AbstractElement
             'xmlns:implocal' => 'http://www.sat.gob.mx/implocal',
             'xsi:schemaLocation' => 'http://www.sat.gob.mx/implocal'
                 . ' http://www.sat.gob.mx/sitio_internet/cfd/implocal/implocal.xsd',
-            'Version' => '1.0',
+            'version' => '1.0',
         ];
     }
 }

--- a/tests/CfdiUtilsTests/CfdiCreatorToStringTest.php
+++ b/tests/CfdiUtilsTests/CfdiCreatorToStringTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace CfdiUtilsTests;
+
+use CfdiUtils\CfdiCreator33;
+
+class CfdiCreatorToStringTest extends TestCase
+{
+    public function testWhenCastingToStringWithExceptionOnlyReturnsAnEmptyString()
+    {
+        /** @var CfdiCreator33&\PHPUnit\Framework\MockObject\MockObject $cfdiCreator */
+        $cfdiCreator = $this->getMockBuilder(CfdiCreator33::class)
+            ->setMethods(['asXml'])
+            ->getMock();
+
+        $cfdiCreator->method('asXml')->willThrowException(new \RuntimeException('exception'));
+
+        $this->assertSame('', (string)$cfdiCreator);
+    }
+
+    public function testCastToStringReturnAValidXml()
+    {
+        $cfdiCreator = new CfdiCreator33();
+        $xml = $cfdiCreator->asXml();
+        $this->assertNotEmpty($xml);
+        $this->assertSame($xml, (string)$cfdiCreator);
+    }
+}


### PR DESCRIPTION
Add method to string for use creator like a string, it is alias to asXml method. this magic method returning an empty string if an exception occurs.

example:
```
$storage->put((string)$creator);
````
In element ImpuestosLocales version is defined in first uppercase letter, this generate error when stamp CFDI, the correct is in lowercase.

`version="1.0"`