### PR TITLE
Create certificate using PEM contents (version 2.12.3)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,14 @@
 - Change visibility of `CfdiUtils\Cleaner\Cleaner#removeIncompleteSchemaLocation()` to private.
 
 
+## Version 2.12.3 2019-09-26
+
+- `CfdiUtils\Certificado\Certificado` can be created using PEM contents and not only a certificate path.
+- `CfdiUtils\Creator33` can use a certificate without associated filename.
+- `CfdiUtils\RetencionesCreator10` can use a certificate without associated filename.
+- `CfdiUtils\Certificado\NodeCertificado` can obtain the certificate without creating a temporary file.
+
+
 ## Version 2.12.2 2019-09-24
 
 - When cannot load an Xml string include `LibXMLError` information into exception, like:

--- a/src/CfdiUtils/Certificado/Certificado.php
+++ b/src/CfdiUtils/Certificado/Certificado.php
@@ -95,6 +95,9 @@ class Certificado
 
     private function extractPemCertificate(string $contents): string
     {
+        if (strlen($contents) < 2000) {
+            return ''; // is too short to be a PEM certificate
+        }
         $openssl = $this->getOpenSSL();
         $decoded = @base64_decode($contents, true) ?: '';
         if ($contents === base64_encode($decoded)) { // is a one liner certificate
@@ -109,7 +112,8 @@ class Certificado
 
     private function obtainPemCertificate(string $contents): string
     {
-        $extracted = $this->extractPemCertificate($contents);
+        $openssl = $this->getOpenSSL();
+        $extracted = $openssl->readPemContents($contents)->certificate();
         if ('' === $extracted) { // cannot extract, could be on DER format
             $extracted = $this->getOpenSSL()->derCerConvertPhp($contents);
         }

--- a/src/CfdiUtils/Certificado/NodeCertificado.php
+++ b/src/CfdiUtils/Certificado/NodeCertificado.php
@@ -1,7 +1,6 @@
 <?php
 namespace CfdiUtils\Certificado;
 
-use CfdiUtils\Internals\TemporaryFile;
 use CfdiUtils\Nodes\NodeInterface;
 
 class NodeCertificado
@@ -99,14 +98,10 @@ class NodeCertificado
      */
     public function obtain(): Certificado
     {
-        $temporaryFile = TemporaryFile::create();
-        // the temporary name was created
-        try {
-            $this->save($temporaryFile->getPath());
-            $certificado = new Certificado($temporaryFile->getPath());
-            return $certificado;
-        } finally {
-            $temporaryFile->remove();
+        $certificado = $this->extract();
+        if ('' === $certificado) {
+            throw new \RuntimeException('The certificado attribute is empty');
         }
+        return new Certificado(base64_encode($certificado));
     }
 }

--- a/src/CfdiUtils/CfdiCreator33.php
+++ b/src/CfdiUtils/CfdiCreator33.php
@@ -77,11 +77,9 @@ class CfdiCreator33 implements
     public function putCertificado(Certificado $certificado, bool $putEmisorRfcNombre = true)
     {
         $this->setCertificado($certificado);
-        $cerfile = $certificado->getFilename();
         $this->comprobante['NoCertificado'] = $certificado->getSerial();
-        if (file_exists($cerfile)) {
-            $this->comprobante['Certificado'] = base64_encode(strval(file_get_contents($cerfile)));
-        }
+        $pemContents = implode('', preg_grep('/^((?!-).)*$/', explode(PHP_EOL, $certificado->getPemContents())));
+        $this->comprobante['Certificado'] = $pemContents;
         if ($putEmisorRfcNombre) {
             $emisor = $this->comprobante->searchNode('cfdi:Emisor');
             if (null === $emisor) {

--- a/src/CfdiUtils/Retenciones/RetencionesCreator10.php
+++ b/src/CfdiUtils/Retenciones/RetencionesCreator10.php
@@ -47,11 +47,9 @@ class RetencionesCreator10 implements
     public function putCertificado(Certificado $certificado)
     {
         $this->setCertificado($certificado);
-        $cerfile = $certificado->getFilename();
         $this->retenciones['NumCert'] = $certificado->getSerial();
-        if (file_exists($cerfile)) {
-            $this->retenciones['Cert'] = base64_encode(strval(file_get_contents($cerfile)));
-        }
+        $pemContents = implode('', preg_grep('/^((?!-).)*$/', explode(PHP_EOL, $certificado->getPemContents())));
+        $this->retenciones['Cert'] = $pemContents;
     }
 
     public function buildCadenaDeOrigen(): string

--- a/tests/CfdiUtilsTests/Certificado/CertificadoTest.php
+++ b/tests/CfdiUtilsTests/Certificado/CertificadoTest.php
@@ -64,6 +64,17 @@ EOD;
         $this->assertTrue($verify);
     }
 
+    public function testConstructUsingPemContents()
+    {
+        $pemfile = $this->utilAsset('certs/CSD01_AAA010101AAA.cer.pem');
+        $contents = file_get_contents($pemfile) ?: '';
+
+        $fromFile = new Certificado($pemfile);
+        $fromContents = new Certificado($contents);
+
+        $this->assertSame($fromFile->getPemContents(), $fromContents->getPemContents());
+    }
+
     public function testVerifyWithInvalidData()
     {
         $dataFile = $this->utilAsset('certs/data-to-sign.txt');

--- a/tests/CfdiUtilsTests/Certificado/NodeCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Certificado/NodeCertificadoTest.php
@@ -106,7 +106,7 @@ class NodeCertificadoTest extends TestCase
         $nodeCertificado = $this->createNodeCertificado(strval(file_get_contents($cfdiSample)));
 
         $certificate = $nodeCertificado->obtain();
-        $this->assertFileNotExists($certificate->getFilename());
+        $this->assertEmpty($certificate->getFilename());
         $this->assertEquals('CTO021007DZ8', $certificate->getRfc());
     }
 }


### PR DESCRIPTION
- `CfdiUtils\Certificado\Certificado` can be created using PEM contents and not only a certificate path.
- `CfdiUtils\Creator33` can use a certificate without associated filename.
- `CfdiUtils\RetencionesCreator10` can use a certificate without associated filename.
- `CfdiUtils\Certificado\NodeCertificado` can obtain the certificate without creating a temporary file.
