### PR TITLE
FormaPago para Nómina

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,13 @@
 - Change visibility of `CfdiUtils\Cleaner\Cleaner#removeIncompleteSchemaLocation()` to private.
 
 
+## Version 2.14.2 2021-03-16
+
+### `FormaPago` on `N - Nómina`
+
+- Validation `TIPOCOMP03` does not apply on documents type `N - Nómina`.
+
+
 ## Version 2.14.1 2021-03-14
 
 ### `MetodoPago` on `N - Nómina`

--- a/docs/validar/validaciones-estandar.md
+++ b/docs/validar/validaciones-estandar.md
@@ -58,7 +58,7 @@ Realiza diferentes validaciones relacionadas con el tipo de comprobante:
 
 - TIPOCOMP01: Si el tipo de comprobante es T, P ó N, entonces no debe existir las condiciones de pago
 - TIPOCOMP02: Si el tipo de comprobante es T, P ó N, entonces no debe existir la definición de impuestos (CFDI33179)
-- TIPOCOMP03: Si el tipo de comprobante es T, P ó N, entonces no debe existir la forma de pago
+- TIPOCOMP03: Si el tipo de comprobante es P, entonces no debe existir la forma de pago (CFDI33103)
 - TIPOCOMP04: Si el tipo de comprobante es T ó P, entonces no debe existir el método de pago (CFDI33123)
 - TIPOCOMP05: Si el tipo de comprobante es T ó P, entonces no debe existir el descuento del comprobante (CFDI33110)
 - TIPOCOMP06: Si el tipo de comprobante es T ó P, entonces no debe existir el descuento de los conceptos (CFDI33179)

--- a/docs/validar/validaciones-estandar.md
+++ b/docs/validar/validaciones-estandar.md
@@ -58,7 +58,7 @@ Realiza diferentes validaciones relacionadas con el tipo de comprobante:
 
 - TIPOCOMP01: Si el tipo de comprobante es T, P ó N, entonces no debe existir las condiciones de pago
 - TIPOCOMP02: Si el tipo de comprobante es T, P ó N, entonces no debe existir la definición de impuestos (CFDI33179)
-- TIPOCOMP03: Si el tipo de comprobante es P, entonces no debe existir la forma de pago (CFDI33103)
+- TIPOCOMP03: Si el tipo de comprobante es T ó P, entonces no debe existir la forma de pago
 - TIPOCOMP04: Si el tipo de comprobante es T ó P, entonces no debe existir el método de pago (CFDI33123)
 - TIPOCOMP05: Si el tipo de comprobante es T ó P, entonces no debe existir el descuento del comprobante (CFDI33110)
 - TIPOCOMP06: Si el tipo de comprobante es T ó P, entonces no debe existir el descuento de los conceptos (CFDI33179)

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobante.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobante.php
@@ -13,7 +13,7 @@ use CfdiUtils\Validate\Status;
  * Valida que:
  * - TIPOCOMP01: Si el tipo de comprobante es T, P ó N, entonces no debe existir las condiciones de pago
  * - TIPOCOMP02: Si el tipo de comprobante es T, P ó N, entonces no debe existir la definición de impuestos (CFDI33179)
- * - TIPOCOMP03: Si el tipo de comprobante es P, entonces no debe existir la forma de pago (CFDI33103)
+ * - TIPOCOMP03: Si el tipo de comprobante es T ó P, entonces no debe existir la forma de pago
  * - TIPOCOMP04: Si el tipo de comprobante es T ó P, entonces no debe existir el método de pago (CFDI33123)
  * - TIPOCOMP05: Si el tipo de comprobante es T ó P, entonces no debe existir el descuento del comprobante (CFDI33110)
  * - TIPOCOMP06: Si el tipo de comprobante es T ó P, entonces no debe existir el descuento de los conceptos (CFDI33179)
@@ -32,7 +32,7 @@ class ComprobanteTipoDeComprobante extends AbstractDiscoverableVersion33
                          . ' entonces no debe existir las condiciones de pago',
             'TIPOCOMP02' => 'Si el tipo de comprobante es T, P ó N,'
                          . ' entonces no debe existir la definición de impuestos (CFDI33179)',
-            'TIPOCOMP03' => 'Si el tipo de comprobante es P, entonces no debe existir la forma de pago (CFDI33103)',
+            'TIPOCOMP03' => 'Si el tipo de comprobante es T ó P, entonces no debe existir la forma de pago',
 
             'TIPOCOMP04' => 'Si el tipo de comprobante es T ó P,'
                          . ' entonces no debe existir el método de pago (CFDI33123)',
@@ -72,6 +72,10 @@ class ComprobanteTipoDeComprobante extends AbstractDiscoverableVersion33
 
         if ('T' === $tipoComprobante || 'P' === $tipoComprobante) {
             $asserts->putStatus(
+                'TIPOCOMP03',
+                Status::when(! $comprobante->offsetExists('FormaPago'))
+            );
+            $asserts->putStatus(
                 'TIPOCOMP04',
                 Status::when(! $comprobante->offsetExists('MetodoPago'))
             );
@@ -104,13 +108,6 @@ class ComprobanteTipoDeComprobante extends AbstractDiscoverableVersion33
             $asserts->putStatus(
                 'TIPOCOMP10',
                 Status::when('MXN' === $comprobante['Moneda'])
-            );
-        }
-
-        if ('P' === $tipoComprobante) {
-            $asserts->putStatus(
-                'TIPOCOMP03',
-                Status::when(! $comprobante->offsetExists('FormaPago'))
             );
         }
     }

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobante.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobante.php
@@ -13,7 +13,7 @@ use CfdiUtils\Validate\Status;
  * Valida que:
  * - TIPOCOMP01: Si el tipo de comprobante es T, P ó N, entonces no debe existir las condiciones de pago
  * - TIPOCOMP02: Si el tipo de comprobante es T, P ó N, entonces no debe existir la definición de impuestos (CFDI33179)
- * - TIPOCOMP03: Si el tipo de comprobante es T, P ó N, entonces no debe existir la forma de pago
+ * - TIPOCOMP03: Si el tipo de comprobante es P, entonces no debe existir la forma de pago (CFDI33103)
  * - TIPOCOMP04: Si el tipo de comprobante es T ó P, entonces no debe existir el método de pago (CFDI33123)
  * - TIPOCOMP05: Si el tipo de comprobante es T ó P, entonces no debe existir el descuento del comprobante (CFDI33110)
  * - TIPOCOMP06: Si el tipo de comprobante es T ó P, entonces no debe existir el descuento de los conceptos (CFDI33179)
@@ -32,7 +32,7 @@ class ComprobanteTipoDeComprobante extends AbstractDiscoverableVersion33
                          . ' entonces no debe existir las condiciones de pago',
             'TIPOCOMP02' => 'Si el tipo de comprobante es T, P ó N,'
                          . ' entonces no debe existir la definición de impuestos (CFDI33179)',
-            'TIPOCOMP03' => 'Si el tipo de comprobante es T, P ó N, entonces no debe existir la forma de pago',
+            'TIPOCOMP03' => 'Si el tipo de comprobante es P, entonces no debe existir la forma de pago (CFDI33103)',
 
             'TIPOCOMP04' => 'Si el tipo de comprobante es T ó P,'
                          . ' entonces no debe existir el método de pago (CFDI33123)',
@@ -68,10 +68,6 @@ class ComprobanteTipoDeComprobante extends AbstractDiscoverableVersion33
                 'TIPOCOMP02',
                 Status::when(null === $comprobante->searchNode('cfdi:Impuestos'))
             );
-            $asserts->putStatus(
-                'TIPOCOMP03',
-                Status::when(! $comprobante->offsetExists('FormaPago'))
-            );
         }
 
         if ('T' === $tipoComprobante || 'P' === $tipoComprobante) {
@@ -96,16 +92,25 @@ class ComprobanteTipoDeComprobante extends AbstractDiscoverableVersion33
                 Status::when($this->isZero($comprobante['Total']))
             );
         }
+
         if ('I' === $tipoComprobante || 'E' === $tipoComprobante || 'N' === $tipoComprobante) {
             $asserts->putStatus(
                 'TIPOCOMP09',
                 Status::when($this->checkConceptosValorUnitarioIsGreaterThanZero($comprobante))
             );
         }
+
         if ('N' === $tipoComprobante) {
             $asserts->putStatus(
                 'TIPOCOMP10',
                 Status::when('MXN' === $comprobante['Moneda'])
+            );
+        }
+
+        if ('P' === $tipoComprobante) {
+            $asserts->putStatus(
+                'TIPOCOMP03',
+                Status::when(! $comprobante->offsetExists('FormaPago'))
             );
         }
     }

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
@@ -68,10 +68,13 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,
+            'FormaPago' => null, // set to null to make clear that it must not exists
+            'MetodoPago' => null, // set to null to make clear that it must not exists
             'SubTotal' => '0',
             'Total' => '0.00',
         ]);
         $this->runValidate();
+        $this->assertStatusEqualsCode(Status::ok(), 'TIPOCOMP03');
         $this->assertStatusEqualsCode(Status::ok(), 'TIPOCOMP04');
         $this->assertStatusEqualsCode(Status::ok(), 'TIPOCOMP05');
         $this->assertStatusEqualsCode(Status::ok(), 'TIPOCOMP06');
@@ -83,13 +86,15 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
      * @param string $tipoDeComprobante
      * @dataProvider providerTP
      */
-    public function testInvalidTPMetodoPago($tipoDeComprobante)
+    public function testInvalidTP($tipoDeComprobante)
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,
+            'FormaPago' => '',
             'MetodoPago' => '',
         ]);
         $this->runValidate();
+        $this->assertStatusEqualsCode(Status::error(), 'TIPOCOMP03');
         $this->assertStatusEqualsCode(Status::error(), 'TIPOCOMP04');
     }
 

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
@@ -35,7 +35,6 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::ok(), 'TIPOCOMP01');
         $this->assertStatusEqualsCode(Status::ok(), 'TIPOCOMP02');
-        $this->assertStatusEqualsCode(Status::ok(), 'TIPOCOMP03');
     }
 
     /**
@@ -54,7 +53,6 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::error(), 'TIPOCOMP01');
         $this->assertStatusEqualsCode(Status::error(), 'TIPOCOMP02');
-        $this->assertStatusEqualsCode(Status::error(), 'TIPOCOMP03');
     }
 
     public function providerTP()


### PR DESCRIPTION
El nodo FormaPago si es requerido para la Nómina.

La validación para tipo de comprobante TIPOCOMP03 indica que no debe de existir si se trata de tipo 'T', 'P' ó 'N', pude ver que esta regla sólo aplica para los comprobantes de pago ('P'), no aplica para traslados ('T') ni para nómina ('N').

La matriz de validación es:

`CFDI33103. Si existe el complemento para recepción de pagos el campo FormaPago no debe existir.`

Nota: los test corren pero no hay un test específico para la forma como queda la regla TIPOCOMP03.

Nota 2: esto ya se había detectado en el issue #53. Con los cambio en v2.14.1 y este queda solucionado.

https://github.com/eclipxe13/CfdiUtils/issues/53#issuecomment-542021858
