### PR TITLE
Version 2.15.0 (PHP 8.0 compatibility)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,6 @@ cache:
 ## Build matrix for lowest and highest possible targets
 environment:
     matrix:
-        - php: 7.2
         - php: 7.3
         - php: 7.4
         - php: 8.0
@@ -76,18 +75,17 @@ install:
           # setup c:\tools\php\php.ini
           if (Test-Path c:\tools\php\php.ini-production) {
               Copy-Item -Path c:\tools\php\php.ini-production -Destination c:\tools\php\php.ini
-              [string]$php_ext_prefix=$(if ($Env:php -lt "7.2") {"php_"} else {""})
               Add-Content c:\tools\php\php.ini "`
                   `n; PHP Custom config `
                   date.timezone=UTC `
                   extension_dir=ext `
                   memory_limit=1G `
-                  extension=${php_ext_prefix}openssl `
-                  extension=${php_ext_prefix}mbstring `
-                  extension=${php_ext_prefix}fileinfo `
-                  extension=${php_ext_prefix}curl `
-                  extension=${php_ext_prefix}xsl `
-                  extension=${php_ext_prefix}soap `
+                  extension=openssl `
+                  extension=mbstring `
+                  extension=fileinfo `
+                  extension=curl `
+                  extension=xsl `
+                  extension=soap `
                   "
           }
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,7 @@ environment:
         - php: 7.2
         - php: 7.3
         - php: 7.4
+        - php: 8.0
 
 init:
     - SET PATH=c:\tools\php;C:\tools\composer;C:\OpenSSL-v111-Win64\bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,8 +14,6 @@ cache:
 ## Build matrix for lowest and highest possible targets
 environment:
     matrix:
-        - php: 7.0
-        - php: 7.1
         - php: 7.2
         - php: 7.3
         - php: 7.4
@@ -115,8 +113,8 @@ install:
           }
     # install project dependences and list available tools
     - cd c:\projects\project
+    - composer remove genkgo/xsl squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
     - appveyor-retry composer install --prefer-dist --no-progress --no-interaction --ansi
-    - dir vendor\bin
     # sat-xml resources as a dependency
     - ps: |
           appveyor-retry appveyor DownloadFile https://github.com/phpcfdi/resources-sat-xml/archive/master.zip -Filename c:\projects\project\build\sat-xml.zip
@@ -126,8 +124,4 @@ install:
 ## Run the actual test
 test_script:
     - cd c:\projects\project
-    - vendor\bin\phpcs.bat -sp src tests
-    - vendor\bin\php-cs-fixer.bat fix --dry-run --verbose
-    - if "%php%"=="7.0" vendor\bin\phpunit.bat --verbose
-    - if not "%php%"=="7.0" vendor\bin\phpunit.bat --testdox --verbose
-    - if "%php%"=="7.3" vendor\bin\phpstan.bat analyse --no-progress --level max src/ tests/
+    - vendor\bin\phpunit.bat --testdox --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 dist: xenial
 
 # php compatibility
-php: ["7.2", "7.3", "7.4"]
+php: ["7.2", "7.3", "7.4", "8.0"]
 
 branches:
     except:
@@ -40,7 +40,7 @@ before_script:
 
 script:
     - vendor/bin/phpcs -sp src/ tests/
-    - vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --verbose
+    - PHP_CS_FIXER_IGNORE_ENV=yes vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --verbose
     - | # create code coverage file
         if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then
             php -dzend_extension=xdebug.so vendor/bin/phpunit --testdox --verbose --coverage-clover="$COVERAGE_FILE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 dist: xenial
 
 # php compatibility
-php: ["7.2", "7.3", "7.4", "8.0"]
+php: ["7.3", "7.4", "8.0"]
 
 branches:
     except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 dist: xenial
 
 # php compatibility
-php: ["7.0", "7.1", "7.2", "7.3", "7.4"]
+php: ["7.2", "7.3", "7.4"]
 
 branches:
     except:
@@ -25,6 +25,14 @@ env:
 
 before_script:
     - phpenv config-rm xdebug.ini || true
+    - | # only require phpstan on FULL_BUILD_PHP_VERSION
+        if [[ $TRAVIS_PHP_VERSION != $FULL_BUILD_PHP_VERSION ]]; then
+            composer remove phpstan/phpstan --dev --no-interaction --no-progress --no-update
+        fi
+    - | # only require genkgo/xsl on PHP >= 7.3
+        if [[ $TRAVIS_PHP_VERSION < "7.3"  ]]; then
+            composer remove genkgo/xsl --dev --no-interaction --no-progress --no-update
+        fi
     - travis_retry composer install --no-interaction --prefer-dist
     - travis_retry npm install
     - travis_retry pip install --user mkdocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,34 +25,33 @@ env:
 
 before_script:
     - phpenv config-rm xdebug.ini || true
-    - | # only require phpstan on FULL_BUILD_PHP_VERSION
+    - travis_retry composer self-update --2 --no-interaction
+    - | # only require full development dependencies on FULL_BUILD_PHP_VERSION
         if [[ $TRAVIS_PHP_VERSION != $FULL_BUILD_PHP_VERSION ]]; then
-            composer remove phpstan/phpstan --dev --no-interaction --no-progress --no-update
+            composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
         fi
     - | # only require genkgo/xsl on PHP >= 7.3
         if [[ $TRAVIS_PHP_VERSION < "7.3"  ]]; then
             composer remove genkgo/xsl --dev --no-interaction --no-progress --no-update
         fi
-    - travis_retry composer install --no-interaction --prefer-dist
-    - travis_retry npm install
-    - travis_retry pip install --user mkdocs
+    - travis_retry composer update --no-interaction --prefer-dist
+    - | # only install full development dependencies on FULL_BUILD_PHP_VERSION
+        if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then
+            travis_retry npm install
+            travis_retry pip install --user mkdocs
+        fi
     - travis_retry bash tests/resource-sat-xml-download build/
 
 script:
-    - vendor/bin/phpcs -sp src/ tests/
-    - PHP_CS_FIXER_IGNORE_ENV=yes vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --verbose
-    - | # create code coverage file
-        if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then
-            php -dzend_extension=xdebug.so vendor/bin/phpunit --testdox --verbose --coverage-clover="$COVERAGE_FILE"
-        else
-            vendor/bin/phpunit --testdox --verbose
-        fi
-    - | # only check phpstan on FULL_BUILD_PHP_VERSION
-        if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then
-            vendor/bin/phpstan --no-progress analyse --level max src/ tests/
-        fi
-    - node node_modules/markdownlint-cli/markdownlint.js *.md docs/
-    - ~/.local/bin/mkdocs build --strict --site-dir build/docs
+    # only phpunit without coverage
+    - if [[ $TRAVIS_PHP_VERSION != $FULL_BUILD_PHP_VERSION ]]; then vendor/bin/phpunit --testdox --verbose; fi
+    # full build
+    - if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then vendor/bin/phpcs -sp src/ tests/; fi
+    - if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --verbose; fi
+    - if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then php -dzend_extension=xdebug.so vendor/bin/phpunit --testdox --verbose --coverage-clover="$COVERAGE_FILE"; fi
+    - if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then vendor/bin/phpstan --no-progress analyse src/ tests/; fi
+    - if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then node node_modules/markdownlint-cli/markdownlint.js *.md docs/; fi
+    - if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then ~/.local/bin/mkdocs build --strict --site-dir build/docs; fi
 
 after_script:
     - | # upload test covegare to scrutinizer

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ before_script:
         if [[ $TRAVIS_PHP_VERSION != $FULL_BUILD_PHP_VERSION ]]; then
             composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
         fi
-    - | # only require genkgo/xsl on PHP >= 7.3
-        if [[ $TRAVIS_PHP_VERSION < "7.3"  ]]; then
-            composer remove genkgo/xsl --dev --no-interaction --no-progress --no-update
-        fi
     - travis_retry composer update --no-interaction --prefer-dist
     - | # only install full development dependencies on FULL_BUILD_PHP_VERSION
         if [[ $TRAVIS_PHP_VERSION == $FULL_BUILD_PHP_VERSION ]]; then

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 This library provides helper objects to work with Mexican CFDI (Comprobante Fiscal Digital por Internet).
 
 :mexico: Visita la **documentación en español** de esta librería en [Read the docs][documentation].
-También te esperamos en el [canal #phpcfdi de discord](https://discord.gg/aFGYXvX).
+También te esperamos en el canal [#phpcfdi de discord](https://discord.gg/aFGYXvX).
 
 The documentation related to this library and its API is documented in [Read the docs][documentation].
 It is written in **spanish language** since is the language of the intented audience.
@@ -40,7 +40,7 @@ CFDI y herramientas del SAT. Y próximamente el lugar donde publicaremos la vers
     - Calculate `Comprobante` sums based on the list of `Conceptos`.
     - Retrieve the CFDI version information.
 - Keep a local copy of the tree of XSD and XSLT file dependences from SAT.
-- Keep a local copy of certificates to avoid download them each time.
+- Keep a local copy of certificates to avoid downloads them each time.
 - Check the SAT WebService to get the status of a CFDI (*Estado*, *EsCancelable* y *EstatusCancelacion*) without WSDL.
 
 
@@ -65,12 +65,20 @@ composer require eclipxe/cfdiutils
 
 ## PHP Support
 
-This library is compatible with PHP versions 7.0 and above.
+This library is compatible with **PHP 7.2 and above**.
 Please, try to use the full potential of the language like type declarations.
 
 The intented support is to be aligned with oldest *Active support* PHP Branch.
 See <https://www.php.net/supported-versions.php> for more details.
 
+| CfdiUtils | PHP Supported versions   | Since      |
+| --------- | ------------------------ | ---------- |
+| 1.0       | 7.0, 7.1                 | 2017-09-27 |
+| 2.0       | 7.0, 7.1                 | 2018-01-01 |
+| 2.0.1     | 7.0, 7.1, 7.2            | 2018-01-03 |
+| 2.8.1     | 7.0, 7.1, 7.2, 7.3       | 2019-03-05 |
+| 2.12.7    | 7.0, 7.1, 7.2, 7.3, 7.4  | 2019-12-04 |
+| 2.15.0    | 7.3, 7.4, 8.0            | 2021-03-17 |
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     "require-dev": {
         "genkgo/xsl": "dev-master",
         "phpunit/phpunit": "^8.5",
+        "dms/phpunit-arraysubset-asserts": "^0.1.1",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
         "phpstan/phpstan": "^0.11"

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "dms/phpunit-arraysubset-asserts": "^0.1.1",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.11"
+        "phpstan/phpstan": "^0.12"
     },
     "autoload": {
         "psr-4": {
@@ -80,7 +80,7 @@
         "dev:test": [
             "@dev:check-style",
             "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "@php vendor/bin/phpstan analyse --no-progress --level max src/ tests/"
+            "@php vendor/bin/phpstan analyse --no-progress --level 5 src/ tests/"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "optimize-autoloader": true
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.2",
         "ext-libxml": "*",
         "ext-dom": "*",
         "ext-xsl": "*",
@@ -43,10 +43,10 @@
     },
     "require-dev": {
         "genkgo/xsl": "^0.6",
-        "phpunit/phpunit": "^6.2|^7.3",
+        "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.9|^0.10|^0.11"
+        "phpstan/phpstan": "^0.11"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     "require-dev": {
         "genkgo/xsl": "dev-master",
         "phpunit/phpunit": "^8.5",
-        "dms/phpunit-arraysubset-asserts": "^0.1.1",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
         "phpstan/phpstan": "^0.12"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "genkgo/xsl": "Allows usage of Genkgo/Xsl transformations"
     },
     "require-dev": {
-        "genkgo/xsl": "^0.6",
+        "genkgo/xsl": "dev-master",
         "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "optimize-autoloader": true
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "ext-libxml": "*",
         "ext-dom": "*",
         "ext-xsl": "*",
@@ -43,7 +43,7 @@
     },
     "require-dev": {
         "genkgo/xsl": "dev-master",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
         "phpstan/phpstan": "^0.12"

--- a/composer.json
+++ b/composer.json
@@ -65,12 +65,12 @@
             "@dev:docs"
         ],
         "dev:check-style": [
-            "vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "vendor/bin/phpcs --colors -sp src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --dry-run --verbose",
+            "@php vendor/bin/phpcs --colors -sp src/ tests/"
         ],
         "dev:fix-style": [
-            "vendor/bin/php-cs-fixer fix --verbose",
-            "vendor/bin/phpcbf --colors -sp src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --verbose",
+            "@php vendor/bin/phpcbf --colors -sp src/ tests/"
         ],
         "dev:docs": [
             "node_modules/markdownlint-cli/markdownlint.js *.md docs/",
@@ -78,8 +78,8 @@
         ],
         "dev:test": [
             "@dev:check-style",
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "vendor/bin/phpstan analyse --no-progress --level max src/ tests/"
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php vendor/bin/phpstan analyse --no-progress --level max src/ tests/"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "dev:test": [
             "@dev:check-style",
             "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "@php vendor/bin/phpstan analyse --no-progress --level 5 src/ tests/"
+            "@php vendor/bin/phpstan analyse --no-progress src/ tests/"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,11 @@
 
 ### 2021-03-17 (branch php8.0)
 
+Improvements:
+
+- Include validation web service version 1.3 new response `ValidacionEFOS` as
+  `StatusResponse::getValidationEfos() string` and `StatusResponse::isEfosListed() bool`.
+
 General:
 
 - Upgrade to PHPUnit 8.5 and upgrade test suite

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,9 +30,23 @@
 
 ## UNRELEASED
 
-### 2020-12-20
+### 2020-12-20 (branch php8.0)
 
 - Validation `SELLO04` fails when there are special caracters like `é` and `LC_CTYPE` is not setup.
+- Remove support for PHP 7.0 and PHP 7.1.
+- Compatilize with PHP 8.0 / OpenSSL:
+    - It does not return resources but objects.
+    - On deprecated functions tun only if PHP version is lower than 8.0 and put annotations for `phpcs`.
+- Upgrade to PHPUnit 8.5 and upgrade test suite
+- AppVeyor: Only run PHPUnit
+- Travis-CI: On PHP != 7.4 only run PHPUnit
+- Travis-CI: On PHP == 7.4 run all the build commands
+- PHPStan: Upgrade to version 0.12, downgrade level to 5.
+- Soft backwards incompatibility changes:
+    - Method __construct() of class CfdiUtils\Validate\Cfdi33\Standard\FechaComprobante became final
+    - Method __construct() of class CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago became final
+    - The return type of CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago#getValidators() changed from no type to array
+    - The parameter $decimals of CfdiUtils\Utils\Format::number() changed from no type to a non-contravariant int
 
 ## Version 2.14.2 2021-03-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,12 @@
 - Change visibility of `CfdiUtils\Cleaner\Cleaner#removeIncompleteSchemaLocation()` to private.
 
 
+## UNRELEASED
+
+### 2020-12-20
+
+- Validation `SELLO04` fails when there are special caracters like `é` and `LC_CTYPE` is not setup.
+
 ## Version 2.14.2 2021-03-16
 
 ### `FormaPago` on `N - Nómina`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,19 +28,19 @@
 - Change visibility of `CfdiUtils\Cleaner\Cleaner#removeIncompleteSchemaLocation()` to private.
 
 
-## UNRELEASED
-
-### 2021-03-17 (branch php8.0)
+## Version 2.15.0 2021-03-17
 
 Improvements:
 
 - Include validation web service version 1.3 new response `ValidacionEFOS` as
   `StatusResponse::getValidationEfos() string` and `StatusResponse::isEfosListed() bool`.
+- Update `ConsultaCFDIServiceSAT.svc.xml`. It is unused, but exists for compatibility.
 
 General:
 
-- Upgrade to PHPUnit 8.5 and upgrade test suite
-- Remove support for PHP 7.0 and PHP 7.1.
+- Upgrade to PHPUnit 9.5 and upgrade test suite.
+- Test classes are declared as final.
+- Remove support for PHP 7.0, PHP 7.1 and PHP 7.2.
 - Compatilize with PHP 8.0 / OpenSSL:
     - openssl functions does not return resources but objects.
     - On deprecated functions run only if PHP version is lower than 8.0 and put annotations for `phpcs`.
@@ -48,6 +48,7 @@ General:
 Bugfixes:
 
 - Validation `SELLO04` fails when there are special caracters like `é` and `LC_CTYPE` is not setup.
+- Fix `COMPIMPUESTOSC01` description typo.
 
 There are some soft backwards incompatibility changes:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,23 +30,35 @@
 
 ## UNRELEASED
 
-### 2020-12-20 (branch php8.0)
+### 2021-03-17 (branch php8.0)
 
-- Validation `SELLO04` fails when there are special caracters like `é` and `LC_CTYPE` is not setup.
+General:
+
+- Upgrade to PHPUnit 8.5 and upgrade test suite
 - Remove support for PHP 7.0 and PHP 7.1.
 - Compatilize with PHP 8.0 / OpenSSL:
-    - It does not return resources but objects.
-    - On deprecated functions tun only if PHP version is lower than 8.0 and put annotations for `phpcs`.
-- Upgrade to PHPUnit 8.5 and upgrade test suite
+    - openssl functions does not return resources but objects.
+    - On deprecated functions run only if PHP version is lower than 8.0 and put annotations for `phpcs`.
+
+Bugfixes:
+
+- Validation `SELLO04` fails when there are special caracters like `é` and `LC_CTYPE` is not setup.
+
+There are some soft backwards incompatibility changes:
+
+- Method __construct() of class CfdiUtils\Validate\Cfdi33\Standard\FechaComprobante became final
+- Method __construct() of class CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago became final
+- The return type of CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago#getValidators() changed from no type to array
+- The parameter $decimals of CfdiUtils\Utils\Format::number() changed from no type to a non-contravariant int
+- The parameter $content of CfdiUtils\Cleaner\Cleaner::staticClean() changed from no type to a non-contravariant string.
+
+Development environment:
+
 - AppVeyor: Only run PHPUnit
 - Travis-CI: On PHP != 7.4 only run PHPUnit
 - Travis-CI: On PHP == 7.4 run all the build commands
 - PHPStan: Upgrade to version 0.12, downgrade level to 5.
-- Soft backwards incompatibility changes:
-    - Method __construct() of class CfdiUtils\Validate\Cfdi33\Standard\FechaComprobante became final
-    - Method __construct() of class CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago became final
-    - The return type of CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago#getValidators() changed from no type to array
-    - The parameter $decimals of CfdiUtils\Utils\Format::number() changed from no type to a non-contravariant int
+
 
 ## Version 2.14.2 2021-03-16
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,6 @@
 # Lista de tareas pendientes e ideas
 
-- Compatibilidad con PHP 7.4
-- Firma de CfdiUtils\Utils\Format::number el argumento $decimals debe ser entero
+- Incrementar la cobertura de PHPStan al nivel máximo.
 
 ## Verificar problemas conocidos
 
@@ -68,7 +67,7 @@ ideas than need a solution:
 ## Validation rules for Pagos
 
 The validation rules for "Complemento de Recepción de pagos" are included since version 2.6 but
-they require more cases of use and a better understanding of the rules published by SAT.
+they require more cases of use, and a better understanding of the rules published by SAT.
 
 
 ## Validation rules for ComercioExterior

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,6 +8,8 @@
 
 Ver: <https://www.phpcfdi.com/sat/problemas-conocidos/descarga-certificados/#problemas-de-caducidad-de-certificados>
 
+*Actualización 2020-10-08*: Este problema se vuelve a presentar.
+
 *Actualización 2020-07-18*: Desde 2019-10-24 este problema parece solucionado.
 
 La descarga de certificados desde `https://rdc.sat.gob.mx/rccf/` falla por un error de configuración

--- a/docs/componentes/estado-sat.md
+++ b/docs/componentes/estado-sat.md
@@ -64,11 +64,11 @@ y cambiar la URL.
 ## Datos que entrega la consulta
 
 El servicio entrega cuatro valores: estado de la consulta, estado del cfdi,
-estado de cancelabilidad y estado de cancelación.
+estado de cancelabilidad, estado de cancelación y validación EFOS.
 
 ### CodigoEstatus (estado de consulta)
 
-Este estado está relacionado a la solicitud de información al SAT. No al CFDI.
+Este estado está relacionado con la solicitud de información al SAT. No al CFDI.
 
 - `S - Comprobante obtenido satisfactoriamente`
 - `N - 601: La expresión impresa proporcionada no es válida`
@@ -101,6 +101,16 @@ Se refiere al estado de la cancelación solicitada previamente.
 - `Plazo vencido`: Cancelado por vencimiento de plazo en que el receptor podía denegarla.
 - `Cancelado con aceptación`: Cancelado con el consentimiento del receptor.
 - `Solicitud rechazada`: No se realizó la cancelación por rechazo.
+
+### ValidacionEFOS (estado del emisor en la lista de EFOS)
+
+El WebService del SAT devuelve dos códigos que asumimos se refieren al emisor del CFDI:
+
+- 200: No se enctró en el listado de EFOS.
+- 100: Se encontró en el listado de EFOS.
+
+Desconocemos si el código se refiere a si estaba listado en el momento de la emisión del CFDI,
+al momento de ser reportado el CFDI al SAT o al momento de consulta.
 
 ## Estados mutuamente excluyentes
 
@@ -156,10 +166,11 @@ $service = new WebService();
 $response = $service->request($request);
 
 // obtener las respuestas
-$response->getCode(); // S - ...
-$response->getCfdi(); // Vigente
-$response->getCancellable(); // Cancelable con aceptación
-$response->getCancellationStatus(); // En proceso
+echo $response->getCode(); // S - ...
+echo $response->getCfdi(); // Vigente
+echo $response->getCancellable(); // Cancelable con aceptación
+echo $response->getCancellationStatus(); // En proceso
+echo $response->getValidationEfos(); // 200
 ```
 
 ## Problema con el webservice del SAT

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@
 [![Coverage Status][badge-coverage]][coverage]
 [![Total Downloads][badge-downloads]][downloads]
 
-[`eclipxe/CfdiUtils`](https://github.com/eclipxe13/CfdiUtils)
+El proyecto [`eclipxe/CfdiUtils`](https://github.com/eclipxe13/CfdiUtils)
 es una librería de PHP para leer, validar y crear CFDI 3.3.
 
 Mira el archivo [README][] para información rápida (en inglés).
@@ -26,7 +26,7 @@ México, en proyectos privados o proyectos libres como el futuro "BuzonCFDI".
 Esta librería se ha liberado como software libre para ayudar a otros desarrolladores a
 trabajar con CFDI y también para obtener su ayuda, todo lo que la comunidad pueda
 contribuir será bien apreciado. Tenemos una comunidad activa y dinámica, nos puedes
-encontrar en el [canal #phpcfdi de discord][discord].
+encontrar en el canal [#phpcfdi de discord][discord].
 
 No olvides visitar <https://www.phpcfdi.com> donde contamos con muchas más librerías relacionadas con
 CFDI y herramientas del SAT. Y próximamente el lugar donde publicaremos la versión `3.y.z`.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,4 @@
 parameters:
+    level: 5
     inferPrivatePropertyTypeFromConstructor: true
 

--- a/src/CfdiUtils/Cleaner/Cleaner.php
+++ b/src/CfdiUtils/Cleaner/Cleaner.php
@@ -356,7 +356,6 @@ class Cleaner
         } else {
             $document = Xml::ownerDocument($element);
         }
-        /** @var DOMNodeList|false $nodelist phpstan does not know that query can return false */
         $nodelist = (new DOMXPath($document))->query($query, $element);
         if (false === $nodelist) {
             $nodelist = new DOMNodeList();

--- a/src/CfdiUtils/Cleaner/Cleaners/SchemaLocationsXsdUrlsFixer.php
+++ b/src/CfdiUtils/Cleaner/Cleaners/SchemaLocationsXsdUrlsFixer.php
@@ -34,7 +34,7 @@ final class SchemaLocationsXsdUrlsFixer
      * Created a new instance based on known CFDI and TFD
      * It also includes the incorrect but allowed TFD 1.0 alternate urls
      *
-     * @return static
+     * @return self
      */
     public static function createWithKnownSatUrls(): self
     {

--- a/src/CfdiUtils/ConsultaCfdiSat/ConsultaCFDIServiceSAT.svc.xml
+++ b/src/CfdiUtils/ConsultaCfdiSat/ConsultaCFDIServiceSAT.svc.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="ConsultaCFDIService" targetNamespace="http://tempuri.org/">
-  <wsp:Policy wsu:Id="BasicHttpsBinding_IConsultaCFDIService_policy">
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://tempuri.org/" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" name="ConsultaCFDIService" targetNamespace="http://tempuri.org/">
+  <wsp:Policy wsu:Id="BasicHttpBinding_IConsultaCFDIService_policy">
     <wsp:ExactlyOne>
       <wsp:All>
         <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
@@ -91,6 +91,7 @@
           <xs:element minOccurs="0" name="EsCancelable" nillable="true" type="xs:string"/>
           <xs:element minOccurs="0" name="Estado" nillable="true" type="xs:string"/>
           <xs:element minOccurs="0" name="EstatusCancelacion" nillable="true" type="xs:string"/>
+          <xs:element minOccurs="0" name="ValidacionEFOS" nillable="true" type="xs:string"/>
         </xs:sequence>
       </xs:complexType>
       <xs:element name="Acuse" nillable="true" type="tns:Acuse"/>
@@ -109,19 +110,7 @@
     </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="BasicHttpBinding_IConsultaCFDIService" type="tns:IConsultaCFDIService">
-    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="Consulta">
-      <soap:operation soapAction="http://tempuri.org/IConsultaCFDIService/Consulta" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:binding name="BasicHttpsBinding_IConsultaCFDIService" type="tns:IConsultaCFDIService">
-    <wsp:PolicyReference URI="#BasicHttpsBinding_IConsultaCFDIService_policy"/>
+    <wsp:PolicyReference URI="#BasicHttpBinding_IConsultaCFDIService_policy"/>
     <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
     <wsdl:operation name="Consulta">
       <soap:operation soapAction="http://tempuri.org/IConsultaCFDIService/Consulta" style="document"/>
@@ -135,9 +124,6 @@
   </wsdl:binding>
   <wsdl:service name="ConsultaCFDIService">
     <wsdl:port name="BasicHttpBinding_IConsultaCFDIService" binding="tns:BasicHttpBinding_IConsultaCFDIService">
-      <soap:address location="https://consultaqr.facturaelectronica.sat.gob.mx/ConsultaCFDIService.svc"/>
-    </wsdl:port>
-    <wsdl:port name="BasicHttpsBinding_IConsultaCFDIService" binding="tns:BasicHttpsBinding_IConsultaCFDIService">
       <soap:address location="https://consultaqr.facturaelectronica.sat.gob.mx/ConsultaCFDIService.svc"/>
     </wsdl:port>
   </wsdl:service>

--- a/src/CfdiUtils/ConsultaCfdiSat/RequestParameters.php
+++ b/src/CfdiUtils/ConsultaCfdiSat/RequestParameters.php
@@ -3,6 +3,7 @@
 namespace CfdiUtils\ConsultaCfdiSat;
 
 use CfdiUtils\Cfdi;
+use UnexpectedValueException;
 
 class RequestParameters
 {
@@ -65,7 +66,7 @@ class RequestParameters
     public function setVersion(string $version)
     {
         if (! in_array($version, ['3.2', '3.3'], true)) {
-            throw new \UnexpectedValueException('The version is not allowed');
+            throw new UnexpectedValueException('The version is not allowed');
         }
         $this->version = $version;
     }

--- a/src/CfdiUtils/ConsultaCfdiSat/StatusResponse.php
+++ b/src/CfdiUtils/ConsultaCfdiSat/StatusResponse.php
@@ -16,16 +16,21 @@ class StatusResponse
     /** @var string */
     private $cancellationStatus;
 
+    /** @var string */
+    private $validationEfos;
+
     public function __construct(
         string $statusCode,
         string $status,
         string $cancellable = '',
-        string $cancellationStatus = ''
+        string $cancellationStatus = '',
+        string $validationEfos = ''
     ) {
         $this->code = $statusCode;
         $this->cfdi = $status;
         $this->cancellable = $cancellable;
         $this->cancellationStatus = $cancellationStatus;
+        $this->validationEfos = $validationEfos;
     }
 
     /**
@@ -90,6 +95,19 @@ class StatusResponse
         return $this->cancellationStatus;
     }
 
+    /**
+     * Validation EFOS values:
+     *
+     * - "100": El emisor se encontró en el listado EFOS
+     * - "200": No se encontró en listado EFOS
+     *
+     * @return string
+     */
+    public function getValidationEfos(): string
+    {
+        return $this->validationEfos;
+    }
+
     public function responseWasOk(): bool
     {
         return ('S - ' === substr($this->code, 0, 4));
@@ -108,5 +126,10 @@ class StatusResponse
     public function isCancelled(): bool
     {
         return ('Cancelado' === $this->cfdi);
+    }
+
+    public function isEfosListed(): bool
+    {
+        return ('100' === $this->validationEfos);
     }
 }

--- a/src/CfdiUtils/ConsultaCfdiSat/WebService.php
+++ b/src/CfdiUtils/ConsultaCfdiSat/WebService.php
@@ -2,7 +2,10 @@
 
 namespace CfdiUtils\ConsultaCfdiSat;
 
+use RuntimeException;
 use SoapClient;
+use SoapVar;
+use stdClass;
 
 class WebService
 {
@@ -73,38 +76,39 @@ class WebService
     {
         $rawResponse = $this->doRequestConsulta($requestParameters->expression());
 
-        if (! ($rawResponse instanceof \stdClass)) {
-            throw new \RuntimeException('The consulta web service did not return any result');
+        if (! ($rawResponse instanceof stdClass)) {
+            throw new RuntimeException('The consulta web service did not return any result');
         }
         $result = (array) $rawResponse;
         if (! isset($result['CodigoEstatus'])) {
-            throw new \RuntimeException('The consulta web service did not have expected ConsultaResult:CodigoEstatus');
+            throw new RuntimeException('The consulta web service did not have expected ConsultaResult:CodigoEstatus');
         }
         if (! isset($result['Estado'])) {
-            throw new \RuntimeException('The consulta web service did not have expected ConsultaResult:Estado');
+            throw new RuntimeException('The consulta web service did not have expected ConsultaResult:Estado');
         }
         return new StatusResponse(
             $result['CodigoEstatus'],
             $result['Estado'],
             $result['EsCancelable'] ?? '',
-            $result['EstatusCancelacion'] ?? ''
+            $result['EstatusCancelacion'] ?? '',
+            $result['ValidacionEFOS'] ?? ''
         );
     }
 
     /**
      * This method exists to be able to mock SOAP call
      *
-     * @internal
      * @param string $expression
-     * @return null|\stdClass
+     * @return null|stdClass
+     *@internal
      */
-    protected function doRequestConsulta(string $expression)
+    protected function doRequestConsulta(string $expression): ?stdClass
     {
         /** @var int $encoding Override because inspectors does not know that second argument can be NULL */
         $encoding = null;
         return $this->getSoapClient()->__soapCall(
             'Consulta',
-            [new \SoapVar($expression, $encoding, '', '', 'expresionImpresa', 'http://tempuri.org/')],
+            [new SoapVar($expression, $encoding, '', '', 'expresionImpresa', 'http://tempuri.org/')],
             ['soapaction' => 'http://tempuri.org/IConsultaCFDIService/Consulta']
         );
     }

--- a/src/CfdiUtils/Elements/Cfdi33/Comprobante.php
+++ b/src/CfdiUtils/Elements/Cfdi33/Comprobante.php
@@ -22,7 +22,7 @@ class Comprobante extends AbstractElement
     public function getCfdiRelacionados(): CfdiRelacionados
     {
         $arguments = func_get_args();
-        if (count($arguments) > 0) {
+        if ([] !== $arguments) {
             trigger_error(
                 'El método getCfdiRelacionados ya no admite atributos, use addCfdiRelacionados en su lugar',
                 E_USER_NOTICE

--- a/src/CfdiUtils/Internals/ShellExecTemplate.php
+++ b/src/CfdiUtils/Internals/ShellExecTemplate.php
@@ -13,7 +13,7 @@ class ShellExecTemplate
     public function create(string $template, array $arguments): array
     {
         $command = [];
-        $parts = array_filter(explode(' ', $template) ?: [], function (string $part): bool {
+        $parts = array_filter(explode(' ', $template), function (string $part): bool {
             return ('' !== $part);
         });
 

--- a/src/CfdiUtils/Internals/StringUncaseReplacer.php
+++ b/src/CfdiUtils/Internals/StringUncaseReplacer.php
@@ -20,7 +20,7 @@ final class StringUncaseReplacer
 
     /**
      * @param array<string, array<string>> $replacements
-     * @return static
+     * @return self
      */
     public static function create(array $replacements): self
     {

--- a/src/CfdiUtils/Nodes/NodeNsDefinitionsMover.php
+++ b/src/CfdiUtils/Nodes/NodeNsDefinitionsMover.php
@@ -11,7 +11,7 @@ class NodeNsDefinitionsMover
 
     public function __construct()
     {
-        $this->setNamespaceFilter(null);
+        $this->setNamespaceFilter();
     }
 
     public function hasNamespaceFilter(): bool

--- a/src/CfdiUtils/Nodes/XmlNodeUtils.php
+++ b/src/CfdiUtils/Nodes/XmlNodeUtils.php
@@ -26,7 +26,7 @@ class XmlNodeUtils
     {
         $element = static::nodeToXmlElement($node);
         $simpleXmlElement = simplexml_import_dom($element);
-        if (false === $simpleXmlElement) {
+        if (! $simpleXmlElement instanceof SimpleXMLElement) {
             throw new \InvalidArgumentException('Cannot convert to SimpleXmlElement');
         }
         return $simpleXmlElement;

--- a/src/CfdiUtils/OpenSSL/OpenSSL.php
+++ b/src/CfdiUtils/OpenSSL/OpenSSL.php
@@ -31,12 +31,11 @@ class OpenSSL
     public function readPemContents(string $contents): PemContainer
     {
         $extractor = new PemExtractor($contents);
-        $pemContainer = new PemContainer(
+        return new PemContainer(
             $extractor->extractCertificate(),
             $extractor->extractPublicKey(),
             $extractor->extractPrivateKey()
         );
-        return $pemContainer;
     }
 
     public function derCerConvertPhp(string $derContent): string

--- a/src/CfdiUtils/PemPrivateKey/PemPrivateKey.php
+++ b/src/CfdiUtils/PemPrivateKey/PemPrivateKey.php
@@ -14,7 +14,7 @@ class PemPrivateKey
     private $contents;
 
     /** @var resource|false */
-    private $privatekey;
+    private $privatekey = false;
 
     /**
      * Create a private key helper class based on a private key PEM formatted

--- a/src/CfdiUtils/PemPrivateKey/PemPrivateKey.php
+++ b/src/CfdiUtils/PemPrivateKey/PemPrivateKey.php
@@ -13,7 +13,7 @@ class PemPrivateKey
     /** @var string */
     private $contents;
 
-    /** @var resource|false */
+    /** @var mixed|false */
     private $privatekey = false;
 
     /**
@@ -98,7 +98,7 @@ class PemPrivateKey
         return (false !== $this->privatekey);
     }
 
-    /** @return resource */
+    /** @return mixed */
     private function getOpenPrivateKey()
     {
         if (false === $this->privatekey) {

--- a/src/CfdiUtils/PemPrivateKey/PemPrivateKey.php
+++ b/src/CfdiUtils/PemPrivateKey/PemPrivateKey.php
@@ -4,6 +4,7 @@ namespace CfdiUtils\PemPrivateKey;
 
 use CfdiUtils\OpenSSL\OpenSSL;
 use CfdiUtils\OpenSSL\OpenSSLPropertyTrait;
+use UnexpectedValueException;
 
 class PemPrivateKey
 {
@@ -12,7 +13,7 @@ class PemPrivateKey
     /** @var string */
     private $contents;
 
-    /** @var resource|null */
+    /** @var resource|false */
     private $privatekey;
 
     /**
@@ -22,8 +23,8 @@ class PemPrivateKey
      * - file contents
      *
      * @param string $key
-     * @param \CfdiUtils\OpenSSL\OpenSSL $openSSL
-     * @throws \UnexpectedValueException if the file is not PEM format
+     * @param OpenSSL|null $openSSL
+     * @throws UnexpectedValueException if the file is not PEM format
      */
     public function __construct(string $key, OpenSSL $openSSL = null)
     {
@@ -39,7 +40,7 @@ class PemPrivateKey
                 throw new \RuntimeException('Empty key');
             }
         } catch (\Throwable $exc) {
-            throw new \UnexpectedValueException('The key is not a file or a string PEM format private key', 0, $exc);
+            throw new UnexpectedValueException('The key is not a file or a string PEM format private key', 0, $exc);
         }
 
         $this->contents = $contents;
@@ -52,7 +53,7 @@ class PemPrivateKey
 
     public function __clone()
     {
-        $this->privatekey = null;
+        $this->privatekey = false;
     }
 
     public function __sleep()
@@ -73,9 +74,12 @@ class PemPrivateKey
 
     public function close()
     {
-        if (null !== $this->privatekey) {
-            openssl_pkey_free($this->privatekey);
-            $this->privatekey = null;
+        if (false !== $this->privatekey) {
+            if (\PHP_VERSION_ID < 80000) {
+                // phpcs:ignore
+                openssl_pkey_free($this->privatekey);
+            }
+            $this->privatekey = false;
         }
     }
 
@@ -91,13 +95,13 @@ class PemPrivateKey
 
     public function isOpen(): bool
     {
-        return (null !== $this->privatekey);
+        return (false !== $this->privatekey);
     }
 
     /** @return resource */
     private function getOpenPrivateKey()
     {
-        if (! is_resource($this->privatekey)) {
+        if (false === $this->privatekey) {
             throw new \RuntimeException('The private key is not open');
         }
         return $this->privatekey;

--- a/src/CfdiUtils/QuickReader/QuickReader.php
+++ b/src/CfdiUtils/QuickReader/QuickReader.php
@@ -69,7 +69,7 @@ class QuickReader extends \stdClass implements \ArrayAccess
     {
         $child = $this->getChildByName($name);
         if (null === $child) {
-            $child = new static($name);
+            $child = new self($name);
         }
 
         return $child;

--- a/src/CfdiUtils/SumasConceptos/SumasConceptos.php
+++ b/src/CfdiUtils/SumasConceptos/SumasConceptos.php
@@ -200,12 +200,12 @@ class SumasConceptos
 
     public function hasTraslados(): bool
     {
-        return (count($this->traslados) > 0);
+        return ([] !== $this->traslados);
     }
 
     public function hasRetenciones(): bool
     {
-        return (count($this->retenciones) > 0);
+        return ([] !== $this->retenciones);
     }
 
     public function getImpuestosTrasladados(): float
@@ -245,12 +245,12 @@ class SumasConceptos
 
     public function hasLocalesTraslados(): bool
     {
-        return (count($this->localesTraslados) > 0);
+        return ([] !== $this->localesTraslados);
     }
 
     public function hasLocalesRetenciones(): bool
     {
-        return (count($this->localesRetenciones) > 0);
+        return ([] !== $this->localesRetenciones);
     }
 
     public function foundAnyConceptWithDiscount(): bool

--- a/src/CfdiUtils/Utils/Format.php
+++ b/src/CfdiUtils/Utils/Format.php
@@ -7,7 +7,7 @@ namespace CfdiUtils\Utils;
  */
 class Format
 {
-    public static function number(float $value, $decimals = 2): string
+    public static function number(float $value, int $decimals = 2): string
     {
         return number_format($value, $decimals, '.', '');
     }

--- a/src/CfdiUtils/Utils/Rfc.php
+++ b/src/CfdiUtils/Utils/Rfc.php
@@ -153,7 +153,6 @@ class Rfc
         }
         $parts = str_split($strdate, 2);
         // year 2000 is leap year (%4 & %100 & %400)
-        /** @var int|false $date phpstan does not know that mktime can return false */
         $date = mktime(0, 0, 0, (int) $parts[1], (int) $parts[2], (int) ('20' . $parts[0]));
         if (false === $date) {
             /** @codeCoverageIgnore it is unlikely to enter this block */

--- a/src/CfdiUtils/Utils/SchemaLocations.php
+++ b/src/CfdiUtils/Utils/SchemaLocations.php
@@ -71,7 +71,7 @@ class SchemaLocations implements Countable, IteratorAggregate
 
     public function isEmpty(): bool
     {
-        return (0 === count($this->pairs));
+        return ([] === $this->pairs);
     }
 
     /**
@@ -103,7 +103,7 @@ class SchemaLocations implements Countable, IteratorAggregate
 
     public function hasAnyNamespaceWithoutLocation(): bool
     {
-        return count($this->getNamespacesWithoutLocation()) > 0;
+        return [] !== $this->getNamespacesWithoutLocation();
     }
 
     public function append(string $namespace, string $location)

--- a/src/CfdiUtils/Validate/Cfdi33/Abstracts/AbstractDiscoverableVersion33.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Abstracts/AbstractDiscoverableVersion33.php
@@ -7,6 +7,10 @@ use CfdiUtils\Validate\Contracts\ValidatorInterface;
 
 abstract class AbstractDiscoverableVersion33 extends AbstractVersion33 implements DiscoverableCreateInterface
 {
+    final public function __construct()
+    {
+    }
+
     public static function createDiscovered(): ValidatorInterface
     {
         return new static();

--- a/src/CfdiUtils/Validate/Cfdi33/Abstracts/AbstractRecepcionPagos10.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Abstracts/AbstractRecepcionPagos10.php
@@ -9,6 +9,10 @@ use CfdiUtils\Validate\Contracts\ValidatorInterface;
 
 abstract class AbstractRecepcionPagos10 extends AbstractVersion33 implements DiscoverableCreateInterface
 {
+    final public function __construct()
+    {
+    }
+
     abstract public function validateRecepcionPagos(NodeInterface $comprobante, Asserts $asserts);
 
     public function validate(NodeInterface $comprobante, Asserts $asserts)

--- a/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pago.php
+++ b/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pago.php
@@ -21,19 +21,8 @@ class Pago extends AbstractRecepcionPagos10
     /** @var Asserts This is the asserts object used in the validation process */
     private $asserts;
 
-    /** @var Pagos\AbstractPagoValidator[] */
+    /** @var Pagos\AbstractPagoValidator[]|null */
     private $validators;
-
-    /**
-     * @param Pagos\AbstractPagoValidator[]|null $validators
-     */
-    public function __construct(array $validators = null)
-    {
-        if (null === $validators) {
-            $validators = $this->createValidators();
-        }
-        $this->validators = $validators;
-    }
 
     /**
      * @return Pagos\AbstractPagoValidator[]
@@ -70,8 +59,11 @@ class Pago extends AbstractRecepcionPagos10
     /**
      * @return Pagos\AbstractPagoValidator[]
      */
-    public function getValidators()
+    public function getValidators(): array
     {
+        if (null === $this->validators) {
+            $this->validators = $this->createValidators();
+        }
         return $this->validators;
     }
 

--- a/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/MontoBetweenIntervalSumOfDocuments.php
+++ b/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/MontoBetweenIntervalSumOfDocuments.php
@@ -42,11 +42,10 @@ class MontoBetweenIntervalSumOfDocuments extends AbstractPagoValidator
         foreach ($documents as $document) {
             $values[] = $this->calculateDocumentAmountBounds($document, $pago);
         }
-        $bounds = [
+        return [
             'lower' => array_sum(array_column($values, 'lower')),
             'upper' => array_sum(array_column($values, 'upper')),
         ];
-        return $bounds;
     }
 
     public function calculateDocumentAmountBounds(NodeInterface $doctoRelacionado, NodeInterface $pago): array

--- a/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/ValidatePagoException.php
+++ b/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/ValidatePagoException.php
@@ -6,7 +6,7 @@ use CfdiUtils\Validate\Status;
 
 class ValidatePagoException extends \Exception
 {
-    private $status = null;
+    private $status;
 
     public function getStatus(): Status
     {

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/ComprobanteImpuestos.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/ComprobanteImpuestos.php
@@ -21,7 +21,7 @@ class ComprobanteImpuestos extends AbstractDiscoverableVersion33
     private function registerAsserts(Asserts $asserts)
     {
         $assertDescriptions = [
-            'COMPIMPUESTOSC01' => 'Si existe el nodo impuestos entonces debe incluir el total detraslados y/o'
+            'COMPIMPUESTOSC01' => 'Si existe el nodo impuestos entonces debe incluir el total de traslados y/o'
                 . ' el total de retenciones',
             'COMPIMPUESTOSC02' => 'Si existe al menos un traslado entonces debe existir el total de traslados',
             'COMPIMPUESTOSC03' => 'Si existe al menos una retención entonces debe existir el total de retenciones',

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/FechaComprobante.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/FechaComprobante.php
@@ -24,13 +24,7 @@ class FechaComprobante extends AbstractDiscoverableVersion33
     private $maximumDate;
 
     /** @var int Tolerancia en segundos */
-    private $tolerance;
-
-    public function __construct(int $maximumDate = null, int $tolerance = 300)
-    {
-        $this->maximumDate = $maximumDate;
-        $this->tolerance = $tolerance;
-    }
+    private $tolerance = 300;
 
     public function getMinimumDate(): int
     {

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/SelloDigitalCertificado.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/SelloDigitalCertificado.php
@@ -186,7 +186,6 @@ class SelloDigitalCertificado extends AbstractDiscoverableVersion33 implements
     protected function castNombre(string $nombre): string
     {
         $nombre = iconv('UTF-8', 'ASCII//TRANSLIT', $nombre) ?: '';
-        $nombre = str_replace([' ', '-', ',', '.', '#', '&', "'", '"'], '', $nombre);
-        return $nombre;
+        return str_replace([' ', '-', ',', '.', '#', '&', "'", '"'], '', $nombre);
     }
 }

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/SelloDigitalCertificado.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/SelloDigitalCertificado.php
@@ -185,10 +185,8 @@ class SelloDigitalCertificado extends AbstractDiscoverableVersion33 implements
 
     protected function castNombre(string $nombre): string
     {
-        return str_replace(
-            [' ', '-', ',', '.', '#', '&', "'", '"'],
-            '',
-            iconv('UTF-8', 'ASCII//TRANSLIT', $nombre) ?: ''
-        );
+        $nombre = iconv('UTF-8', 'ASCII//TRANSLIT', $nombre) ?: '';
+        $nombre = str_replace([' ', '-', ',', '.', '#', '&', "'", '"'], '', $nombre);
+        return $nombre;
     }
 }

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/SelloDigitalCertificado.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/SelloDigitalCertificado.php
@@ -180,12 +180,13 @@ class SelloDigitalCertificado extends AbstractDiscoverableVersion33 implements
 
     protected function compareNames(string $first, string $second): bool
     {
-        return (0 === strcasecmp($this->castNombre($first), $this->castNombre($second)));
+        return ($this->castNombre($first) === $this->castNombre($second));
     }
 
     protected function castNombre(string $nombre): string
     {
         $nombre = iconv('UTF-8', 'ASCII//TRANSLIT', $nombre) ?: '';
-        return str_replace([' ', '-', ',', '.', '#', '&', "'", '"'], '', $nombre);
+        $nombre = str_replace([' ', '-', ',', '.', '#', '&', "'", '"', '~', '¨', '^'], '', $nombre);
+        return mb_strtoupper($nombre);
     }
 }

--- a/tests/CfdiUtilsTests/CadenaOrigen/DOMBuilderTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/DOMBuilderTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\CadenaOrigen;
 use CfdiUtils\CadenaOrigen\DOMBuilder;
 use CfdiUtils\CadenaOrigen\XsltBuilderInterface;
 
-class DOMBuilderTest extends GenericBuilderTestCase
+final class DOMBuilderTest extends GenericBuilderTestCase
 {
     protected function createBuilder(): XsltBuilderInterface
     {

--- a/tests/CfdiUtilsTests/CadenaOrigen/GenericBuilderTestCase.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/GenericBuilderTestCase.php
@@ -19,7 +19,7 @@ abstract class GenericBuilderTestCase extends TestCase
      * @see procedureCreateCadenaOrigenExpectedContent
      * @return array
      */
-    public function providerCfdiToCadenaOrigen()
+    public function providerCfdiToCadenaOrigen(): array
     {
         return [
             ['cfdi32-real.xml', 'cfdi32-real-cadenaorigen.txt', CfdiDefaultLocations::XSLT_32],
@@ -33,7 +33,7 @@ abstract class GenericBuilderTestCase extends TestCase
      * @param string $xsltLocation
      * @dataProvider providerCfdiToCadenaOrigen
      */
-    public function testCfdiToCadenaOrigen($xmlLocation, $expectedTransformation, $xsltLocation)
+    public function testCfdiToCadenaOrigen(string $xmlLocation, string $expectedTransformation, string $xsltLocation)
     {
         $xsltLocation = $this->downloadResourceIfNotExists($xsltLocation);
 

--- a/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\CadenaOrigen;
 use CfdiUtils\CadenaOrigen\GenkgoXslBuilder;
 use CfdiUtils\CadenaOrigen\XsltBuilderInterface;
 
-class GenkgoXslBuilderTest extends GenericBuilderTestCase
+final class GenkgoXslBuilderTest extends GenericBuilderTestCase
 {
     protected function setUp(): void
     {

--- a/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
@@ -7,6 +7,13 @@ use CfdiUtils\CadenaOrigen\XsltBuilderInterface;
 
 class GenkgoXslBuilderTest extends GenericBuilderTestCase
 {
+    protected function setUp(): void
+    {
+        if (! class_exists(\Genkgo\Xsl\XsltProcessor::class)) {
+            $this->markTestSkipped('Genkgo/Xsl is not installed');
+        }
+    }
+
     protected function createBuilder(): XsltBuilderInterface
     {
         return new GenkgoXslBuilder();

--- a/tests/CfdiUtilsTests/CadenaOrigen/SaxonbCliBuilderTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/SaxonbCliBuilderTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\CadenaOrigen\SaxonbCliBuilder;
 use CfdiUtils\CadenaOrigen\XsltBuilderInterface;
 use CfdiUtils\CadenaOrigen\XsltBuildException;
 
-class SaxonbCliBuilderTest extends GenericBuilderTestCase
+final class SaxonbCliBuilderTest extends GenericBuilderTestCase
 {
     protected function createBuilder(): XsltBuilderInterface
     {

--- a/tests/CfdiUtilsTests/CadenaOrigen/XsltBuilderPropertyTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/XsltBuilderPropertyTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\CadenaOrigen\XsltBuilderPropertyInterface;
 use CfdiUtils\CadenaOrigen\XsltBuilderPropertyTrait;
 use CfdiUtilsTests\TestCase;
 
-class XsltBuilderPropertyTest extends TestCase
+final class XsltBuilderPropertyTest extends TestCase
 {
     public function testXsltBuilderPropertyWithoutSet()
     {

--- a/tests/CfdiUtilsTests/Certificado/CerRetrieverTest.php
+++ b/tests/CfdiUtilsTests/Certificado/CerRetrieverTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Certificado\Certificado;
 use CfdiUtils\Certificado\SatCertificateNumber;
 use CfdiUtilsTests\TestCase;
 
-class CerRetrieverTest extends TestCase
+final class CerRetrieverTest extends TestCase
 {
     public function testRetrieveNonExistent()
     {

--- a/tests/CfdiUtilsTests/Certificado/CerRetrieverTest.php
+++ b/tests/CfdiUtilsTests/Certificado/CerRetrieverTest.php
@@ -35,7 +35,7 @@ final class CerRetrieverTest extends TestCase
         if (file_exists($localPath)) {
             unlink($localPath);
         }
-        $this->assertFileNotExists($localPath);
+        $this->assertFileDoesNotExist($localPath);
 
         $retriever->retrieve($remoteUrl);
         $this->assertFileExists($localPath);

--- a/tests/CfdiUtilsTests/Certificado/CertificadoPropertyTest.php
+++ b/tests/CfdiUtilsTests/Certificado/CertificadoPropertyTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Certificado\CertificadoPropertyInterface;
 use CfdiUtils\Certificado\CertificadoPropertyTrait;
 use CfdiUtilsTests\TestCase;
 
-class CertificadoPropertyTest extends TestCase
+final class CertificadoPropertyTest extends TestCase
 {
     public function testCertificadoProperty()
     {

--- a/tests/CfdiUtilsTests/Certificado/CertificadoTest.php
+++ b/tests/CfdiUtilsTests/Certificado/CertificadoTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Certificado;
 use CfdiUtils\Certificado\Certificado;
 use CfdiUtilsTests\TestCase;
 
-class CertificadoTest extends TestCase
+final class CertificadoTest extends TestCase
 {
     public function testConstructWithValidExample()
     {

--- a/tests/CfdiUtilsTests/Certificado/CertificadoTest.php
+++ b/tests/CfdiUtilsTests/Certificado/CertificadoTest.php
@@ -134,7 +134,6 @@ EOD;
     public function testConstructCertificateUsingPathThatIsBase64()
     {
         $workingdir = $this->utilAsset('certs/');
-        /** @var string $previousPath phpstan complains about getcwd returning FALSE */
         $previousPath = getcwd();
         chdir($workingdir);
         try {

--- a/tests/CfdiUtilsTests/Certificado/CertificateDownloaderHelper.php
+++ b/tests/CfdiUtilsTests/Certificado/CertificateDownloaderHelper.php
@@ -14,7 +14,7 @@ use XmlResourceRetriever\Downloader\PhpDownloader;
  *
  * @see https://www.phpcfdi.com/sat/problemas-conocidos/descarga-certificados/
  */
-class CertificateDownloaderHelper implements DownloaderInterface
+final class CertificateDownloaderHelper implements DownloaderInterface
 {
     /** @var PhpDownloader */
     private $realDownloader;

--- a/tests/CfdiUtilsTests/Certificado/NodeCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Certificado/NodeCertificadoTest.php
@@ -9,7 +9,7 @@ use CfdiUtilsTests\TestCase;
 
 class NodeCertificadoTest extends TestCase
 {
-    private function createNodeCertificado(string $contents)
+    private function createNodeCertificado(string $contents): NodeCertificado
     {
         return new NodeCertificado(XmlNodeUtils::nodeFromXmlString($contents));
     }

--- a/tests/CfdiUtilsTests/Certificado/NodeCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Certificado/NodeCertificadoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Internals\TemporaryFile;
 use CfdiUtils\Nodes\XmlNodeUtils;
 use CfdiUtilsTests\TestCase;
 
-class NodeCertificadoTest extends TestCase
+final class NodeCertificadoTest extends TestCase
 {
     private function createNodeCertificado(string $contents): NodeCertificado
     {

--- a/tests/CfdiUtilsTests/Certificado/SatCertificateNumberTest.php
+++ b/tests/CfdiUtilsTests/Certificado/SatCertificateNumberTest.php
@@ -7,7 +7,7 @@ use CfdiUtilsTests\TestCase;
 
 class SatCertificateNumberTest extends TestCase
 {
-    public function providerValidNumbers()
+    public function providerValidNumbers(): array
     {
         return [
             ['00000000000000000000'],
@@ -15,7 +15,7 @@ class SatCertificateNumberTest extends TestCase
         ];
     }
 
-    public function providerInvalidNumbers()
+    public function providerInvalidNumbers(): array
     {
         return [
             'empty' => [''],
@@ -29,7 +29,7 @@ class SatCertificateNumberTest extends TestCase
      * @param string $value
      * @dataProvider providerValidNumbers
      */
-    public function testIsValidCertificateNumberWithCorrectValues($value)
+    public function testIsValidCertificateNumberWithCorrectValues(string $value)
     {
         $this->assertSame(true, SatCertificateNumber::isValidCertificateNumber($value));
         $number = new SatCertificateNumber($value);
@@ -41,7 +41,7 @@ class SatCertificateNumberTest extends TestCase
      * @param string $value
      * @dataProvider providerInvalidNumbers
      */
-    public function testIsValidCertificateNumberWithIncorrectValues($value)
+    public function testIsValidCertificateNumberWithIncorrectValues(string $value)
     {
         $this->assertSame(false, SatCertificateNumber::isValidCertificateNumber($value));
 

--- a/tests/CfdiUtilsTests/Certificado/SatCertificateNumberTest.php
+++ b/tests/CfdiUtilsTests/Certificado/SatCertificateNumberTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Certificado;
 use CfdiUtils\Certificado\SatCertificateNumber;
 use CfdiUtilsTests\TestCase;
 
-class SatCertificateNumberTest extends TestCase
+final class SatCertificateNumberTest extends TestCase
 {
     public function providerValidNumbers(): array
     {

--- a/tests/CfdiUtilsTests/Certificado/SerialNumberTest.php
+++ b/tests/CfdiUtilsTests/Certificado/SerialNumberTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Certificado;
 use CfdiUtils\Certificado\SerialNumber;
 use PHPUnit\Framework\TestCase;
 
-class SerialNumberTest extends TestCase
+final class SerialNumberTest extends TestCase
 {
     public function testAsDecimalAsAscii()
     {

--- a/tests/CfdiUtilsTests/CfdiCreatorFromExistentTest.php
+++ b/tests/CfdiUtilsTests/CfdiCreatorFromExistentTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Certificado\Certificado;
 use CfdiUtils\CfdiCreator33;
 use CfdiUtils\Nodes\XmlNodeUtils;
 
-class CfdiCreatorFromExistentTest extends TestCase
+final class CfdiCreatorFromExistentTest extends TestCase
 {
     public function testNewUsingNode()
     {

--- a/tests/CfdiUtilsTests/CfdiCreatorToStringTest.php
+++ b/tests/CfdiUtilsTests/CfdiCreatorToStringTest.php
@@ -4,7 +4,7 @@ namespace CfdiUtilsTests;
 
 use CfdiUtils\CfdiCreator33;
 
-class CfdiCreatorToStringTest extends TestCase
+final class CfdiCreatorToStringTest extends TestCase
 {
     public function testWhenCastingToStringWithExceptionOnlyReturnsAnEmptyString()
     {

--- a/tests/CfdiUtilsTests/CfdiQuickReaderTest.php
+++ b/tests/CfdiUtilsTests/CfdiQuickReaderTest.php
@@ -10,7 +10,7 @@ class CfdiQuickReaderTest extends TestCase
     /** @var QuickReader */
     private $comprobante;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $contents = strval(file_get_contents($this->utilAsset('cfdi33-real.xml')));

--- a/tests/CfdiUtilsTests/CfdiQuickReaderTest.php
+++ b/tests/CfdiUtilsTests/CfdiQuickReaderTest.php
@@ -32,11 +32,11 @@ class CfdiQuickReaderTest extends TestCase
         $iva = 0;
         foreach (($this->comprobante->impuestos->traslados)('traslado') as $traslado) {
             if ('002' === $traslado['iMpUeStO']) {
-                $iva = $iva + $traslado['Importe'];
+                $iva = $iva + floatval($traslado['Importe']);
             }
         }
 
-        $this->assertEquals(273.46, $iva, '', 0.001);
+        $this->assertEqualsWithDelta(273.46, $iva, 0.001);
     }
 
     public function testAccessToNestedAttributeSecondLevel()
@@ -62,6 +62,6 @@ class CfdiQuickReaderTest extends TestCase
             $sum += (float) $concepto['importe'];
         }
 
-        $this->assertEquals(1709.12, $sum, '', 0.001);
+        $this->assertEqualsWithDelta(1709.12, $sum, 0.001);
     }
 }

--- a/tests/CfdiUtilsTests/CfdiQuickReaderTest.php
+++ b/tests/CfdiUtilsTests/CfdiQuickReaderTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests;
 use CfdiUtils\Cfdi;
 use CfdiUtils\QuickReader\QuickReader;
 
-class CfdiQuickReaderTest extends TestCase
+final class CfdiQuickReaderTest extends TestCase
 {
     /** @var QuickReader */
     private $comprobante;

--- a/tests/CfdiUtilsTests/CfdiTest.php
+++ b/tests/CfdiUtilsTests/CfdiTest.php
@@ -4,7 +4,7 @@ namespace CfdiUtilsTests;
 
 use CfdiUtils\Cfdi;
 
-class CfdiTest extends TestCase
+final class CfdiTest extends TestCase
 {
     public function testNewFromStringWithEmptyXml()
     {

--- a/tests/CfdiUtilsTests/CfdiValidator33Test.php
+++ b/tests/CfdiUtilsTests/CfdiValidator33Test.php
@@ -8,7 +8,7 @@ use CfdiUtils\CfdiValidator33;
 use CfdiUtils\Nodes\Node;
 use CfdiUtils\Nodes\XmlNodeUtils;
 
-class CfdiValidator33Test extends TestCase
+final class CfdiValidator33Test extends TestCase
 {
     public function testConstructWithoutArguments()
     {

--- a/tests/CfdiUtilsTests/CfdiVersionTest.php
+++ b/tests/CfdiUtilsTests/CfdiVersionTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\CfdiVersion;
 use CfdiUtils\Nodes\Node;
 use CfdiUtils\Nodes\XmlNodeUtils;
 
-class CfdiVersionTest extends TestCase
+final class CfdiVersionTest extends TestCase
 {
     public function providerCfdiVersion(): array
     {

--- a/tests/CfdiUtilsTests/CfdiVersionTest.php
+++ b/tests/CfdiUtilsTests/CfdiVersionTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Nodes\XmlNodeUtils;
 
 class CfdiVersionTest extends TestCase
 {
-    public function providerCfdiVersion()
+    public function providerCfdiVersion(): array
     {
         return [
             '3.3' => ['3.3', 'Version', '3.3'],
@@ -30,7 +30,7 @@ class CfdiVersionTest extends TestCase
      * @param string|null $value
      * @dataProvider providerCfdiVersion
      */
-    public function testCfdiVersion($expected, $attribute, $value)
+    public function testCfdiVersion(string $expected, string $attribute, ?string $value)
     {
         $node = new Node('cfdi', [$attribute => $value]);
         $cfdiVersion = new CfdiVersion();

--- a/tests/CfdiUtilsTests/Cleaner/BeforeLoad/BeforeLoadCleanerTest.php
+++ b/tests/CfdiUtilsTests/Cleaner/BeforeLoad/BeforeLoadCleanerTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Cleaner\BeforeLoad\BeforeLoadCleaner;
 use CfdiUtils\Cleaner\BeforeLoad\BeforeLoadCleanerInterface;
 use CfdiUtilsTests\TestCase;
 
-class BeforeLoadCleanerTest extends TestCase
+final class BeforeLoadCleanerTest extends TestCase
 {
     public function testImplementsBeforeLoadCleanerInterface()
     {

--- a/tests/CfdiUtilsTests/Cleaner/BeforeLoad/ChangeXmlnsSchemaLocationTest.php
+++ b/tests/CfdiUtilsTests/Cleaner/BeforeLoad/ChangeXmlnsSchemaLocationTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Cleaner\BeforeLoad\BeforeLoadCleanerInterface;
 use CfdiUtils\Cleaner\BeforeLoad\ChangeXmlnsSchemaLocation;
 use CfdiUtilsTests\TestCase;
 
-class ChangeXmlnsSchemaLocationTest extends TestCase
+final class ChangeXmlnsSchemaLocationTest extends TestCase
 {
     public function testImplementsBeforeLoadCleanerInterface()
     {

--- a/tests/CfdiUtilsTests/Cleaner/BeforeLoad/RemoveDuplicatedCfdi3NamespaceTest.php
+++ b/tests/CfdiUtilsTests/Cleaner/BeforeLoad/RemoveDuplicatedCfdi3NamespaceTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Cleaner\BeforeLoad\BeforeLoadCleanerInterface;
 use CfdiUtils\Cleaner\BeforeLoad\RemoveDuplicatedCfdi3Namespace;
 use CfdiUtilsTests\TestCase;
 
-class RemoveDuplicatedCfdi3NamespaceTest extends TestCase
+final class RemoveDuplicatedCfdi3NamespaceTest extends TestCase
 {
     public function testImplementsBeforeLoadCleanerInterface()
     {

--- a/tests/CfdiUtilsTests/Cleaner/CleanerTest.php
+++ b/tests/CfdiUtilsTests/Cleaner/CleanerTest.php
@@ -154,7 +154,7 @@ final class CleanerTest extends TestCase
         $domFirst = $cleaner->retrieveDocument();
         $domSecond = $cleaner->retrieveDocument();
         $this->assertNotSame($domFirst, $domSecond);
-        $this->assertXmlStringEqualsXmlString($domFirst, $domSecond);
+        $this->assertXmlStringEqualsXmlString($domFirst->saveXML(), $domSecond->saveXML());
     }
 
     public function testRemoveNonSatNSschemaLocationsWithNotEvenSchemaLocationContents()

--- a/tests/CfdiUtilsTests/Cleaner/CleanerTest.php
+++ b/tests/CfdiUtilsTests/Cleaner/CleanerTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Cleaner\Cleaner;
 use CfdiUtils\Cleaner\CleanerException;
 use CfdiUtilsTests\TestCase;
 
-class CleanerTest extends TestCase
+final class CleanerTest extends TestCase
 {
     public function testConstructorWithEmptyText()
     {

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/ConfigTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/ConfigTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\ConsultaCfdiSat;
 use CfdiUtils\ConsultaCfdiSat\Config;
 use CfdiUtilsTests\TestCase;
 
-class ConfigTest extends TestCase
+final class ConfigTest extends TestCase
 {
     public function testConstructorDefaultValues()
     {

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/RequestParametersTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/RequestParametersTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Cfdi;
 use CfdiUtils\ConsultaCfdiSat\RequestParameters;
 use CfdiUtilsTests\TestCase;
 
-class RequestParametersTest extends TestCase
+final class RequestParametersTest extends TestCase
 {
     public function testConstructorAndGetters()
     {

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/RequestParametersTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/RequestParametersTest.php
@@ -22,7 +22,7 @@ class RequestParametersTest extends TestCase
         $this->assertSame('AAA010101AAA', $parameters->getRfcEmisor());
         $this->assertSame('COSC8001137NA', $parameters->getRfcReceptor());
         $this->assertSame('1,234.5678', $parameters->getTotal());
-        $this->assertEquals(1234.5678, $parameters->getTotalFloat(), '', 0.0000001);
+        $this->assertEqualsWithDelta(1234.5678, $parameters->getTotalFloat(), 0.0000001);
         $this->assertSame('CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC', $parameters->getUuid());
         $this->assertSame('0123456789', $parameters->getSello());
 
@@ -69,7 +69,7 @@ class RequestParametersTest extends TestCase
         $this->assertSame('XAXX010101000', $parameters->getRfcReceptor());
         $this->assertSame('80824F3B-323E-407B-8F8E-40D83FE2E69F', $parameters->getUuid());
         $this->assertStringEndsWith('YRbgmmVYiA==', $parameters->getSello());
-        $this->assertEquals(4685.00, $parameters->getTotalFloat(), '', 0.001);
+        $this->assertEqualsWithDelta(4685.00, $parameters->getTotalFloat(), 0.001);
     }
 
     public function testCreateFromCfdiVersion33()
@@ -82,7 +82,7 @@ class RequestParametersTest extends TestCase
         $this->assertSame('DIM8701081LA', $parameters->getRfcReceptor());
         $this->assertSame('CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC', $parameters->getUuid());
         $this->assertStringEndsWith('XmE4/OAgdg==', $parameters->getSello());
-        $this->assertEquals(2010.01, $parameters->getTotalFloat(), '', 0.001);
+        $this->assertEqualsWithDelta(2010.01, $parameters->getTotalFloat(), 0.001);
     }
 
     /**
@@ -96,9 +96,8 @@ class RequestParametersTest extends TestCase
      *           ["1.1", "1.1"]
      *           ["0", "0.0"]
      *           ["0.1234567", "0.123457"]
-     *
      */
-    public function testExpressionTotalExamples($total, $expected)
+    public function testExpressionTotalExamples(string $total, string $expected)
     {
         $parameters = new RequestParameters(
             '3.3',
@@ -109,6 +108,6 @@ class RequestParametersTest extends TestCase
             '0123456789'
         );
 
-        $this->assertContains('&tt=' . $expected . '&', $parameters->expression());
+        $this->assertStringContainsString('&tt=' . $expected . '&', $parameters->expression());
     }
 }

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/StatusResponseTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/StatusResponseTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\ConsultaCfdiSat;
 use CfdiUtils\ConsultaCfdiSat\StatusResponse;
 use CfdiUtilsTests\TestCase;
 
-class StatusResponseTest extends TestCase
+final class StatusResponseTest extends TestCase
 {
     public function testConsultaResponseExpectedOk()
     {

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
@@ -9,6 +9,7 @@ use CfdiUtils\ConsultaCfdiSat\WebService;
 use CfdiUtilsTests\TestCase;
 use SoapClient;
 use SoapFault;
+use DMS\PHPUnitExtensions\ArraySubset\Assert as ArraySubsetAssert;
 
 /**
  * This test case is performing real request to SAT WebService.
@@ -34,7 +35,6 @@ class WebServiceConsumingTest extends TestCase
             return $ws->request($request);
         } catch (SoapFault $exception) {
             $this->markTestSkipped("SAT Service: {$exception->getMessage()}");
-            throw $exception;
         }
     }
 
@@ -44,7 +44,6 @@ class WebServiceConsumingTest extends TestCase
             return $ws->getSoapClient();
         } catch (SoapFault $exception) {
             $this->markTestSkipped("SAT Service: {$exception->getMessage()}");
-            throw $exception;
         }
     }
 
@@ -72,7 +71,7 @@ class WebServiceConsumingTest extends TestCase
         // check context
         $context = $soapClient->{'_stream_context'};
         $options = stream_context_get_options($context);
-        $this->assertArraySubset(['ssl' => ['verify_peer' => false]], $options);
+        ArraySubsetAssert::assertArraySubset(['ssl' => ['verify_peer' => false]], $options);
     }
 
     public function testValidDocumentVersion33()

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
@@ -19,7 +19,7 @@ use SoapFault;
  * The work around is to mark test skipped if we get a SoapFault when call
  * request or getSoapClient methods
  */
-class WebServiceConsumingTest extends TestCase
+final class WebServiceConsumingTest extends TestCase
 {
     private function createWebServiceObject(): WebService
     {

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
@@ -7,9 +7,9 @@ use CfdiUtils\ConsultaCfdiSat\RequestParameters;
 use CfdiUtils\ConsultaCfdiSat\StatusResponse;
 use CfdiUtils\ConsultaCfdiSat\WebService;
 use CfdiUtilsTests\TestCase;
+use DMS\PHPUnitExtensions\ArraySubset\Assert as ArraySubsetAssert;
 use SoapClient;
 use SoapFault;
-use DMS\PHPUnitExtensions\ArraySubset\Assert as ArraySubsetAssert;
 
 /**
  * This test case is performing real request to SAT WebService.

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
@@ -92,6 +92,7 @@ class WebServiceConsumingTest extends TestCase
         $this->assertSame('Vigente', $return->getCfdi());
         $this->assertSame('Cancelable sin aceptación', $return->getCancellable());
         $this->assertSame('', $return->getCancellationStatus());
+        $this->assertSame('200', $return->getValidationEfos());
     }
 
     public function testValidDocumentVersion32()
@@ -108,6 +109,9 @@ class WebServiceConsumingTest extends TestCase
 
         $this->assertTrue($return->responseWasOk());
         $this->assertTrue($return->isVigente());
+        $this->assertSame('Cancelable sin aceptación', $return->getCancellable());
+        $this->assertSame('', $return->getCancellationStatus());
+        $this->assertSame('200', $return->getValidationEfos());
     }
 
     public function testConsumeWebServiceWithNotFoundDocument()
@@ -128,6 +132,7 @@ class WebServiceConsumingTest extends TestCase
         $this->assertStringStartsWith('No Encontrado', $return->getCfdi());
         $this->assertFalse($return->responseWasOk());
         $this->assertTrue($return->isNotFound());
+        $this->assertFalse($return->isEfosListed());
     }
 
     public function testConsumeWebServiceWithCancelledDocument()
@@ -145,5 +150,6 @@ class WebServiceConsumingTest extends TestCase
 
         $this->assertTrue($return->responseWasOk());
         $this->assertTrue($return->isCancelled());
+        $this->assertFalse($return->isEfosListed());
     }
 }

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
@@ -66,9 +66,11 @@ class WebServiceConsumingTest extends TestCase
         $soapClient = $this->tolerantSoapClient($ws);
 
         // check timeout
+        /** @phpstan-ignore-next-line the variable is internal */
         $this->assertSame(60, $soapClient->{'_connection_timeout'});
 
         // check context
+        /** @phpstan-ignore-next-line the variable is internal */
         $context = $soapClient->{'_stream_context'};
         $options = stream_context_get_options($context);
         ArraySubsetAssert::assertArraySubset(['ssl' => ['verify_peer' => false]], $options);

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
@@ -7,7 +7,6 @@ use CfdiUtils\ConsultaCfdiSat\RequestParameters;
 use CfdiUtils\ConsultaCfdiSat\StatusResponse;
 use CfdiUtils\ConsultaCfdiSat\WebService;
 use CfdiUtilsTests\TestCase;
-use DMS\PHPUnitExtensions\ArraySubset\Assert as ArraySubsetAssert;
 use SoapClient;
 use SoapFault;
 
@@ -73,7 +72,7 @@ class WebServiceConsumingTest extends TestCase
         /** @phpstan-ignore-next-line the variable is internal */
         $context = $soapClient->{'_stream_context'};
         $options = stream_context_get_options($context);
-        ArraySubsetAssert::assertArraySubset(['ssl' => ['verify_peer' => false]], $options);
+        $this->assertSame(false, $options['ssl']['verify_peer'] ?? null);
     }
 
     public function testValidDocumentVersion33()

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\ConsultaCfdiSat\RequestParameters;
 use CfdiUtils\ConsultaCfdiSat\WebService;
 use CfdiUtilsTests\TestCase;
 
-class WebServiceTest extends TestCase
+final class WebServiceTest extends TestCase
 {
     public function testConstructWithNoConfig()
     {

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceTest.php
@@ -24,7 +24,7 @@ class WebServiceTest extends TestCase
         $this->assertSame($config, $ws->getConfig());
     }
 
-    public function providerRequestWithBadRawResponse()
+    public function providerRequestWithBadRawResponse(): array
     {
         return [
             'response invalid' => [
@@ -51,7 +51,7 @@ class WebServiceTest extends TestCase
      * @param string $expectedMessage
      * @dataProvider providerRequestWithBadRawResponse
      */
-    public function testRequestWithBadRawResponse($rawResponse, string $expectedMessage)
+    public function testRequestWithBadRawResponse(?\stdClass $rawResponse, string $expectedMessage)
     {
         /** @var WebService&\PHPUnit\Framework\MockObject\MockObject $webService */
         $webService = $this->getMockBuilder(WebService::class)

--- a/tests/CfdiUtilsTests/CreateComprobanteCaseTest.php
+++ b/tests/CfdiUtilsTests/CreateComprobanteCaseTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\CfdiCreator33;
 use CfdiUtils\Utils\Format;
 use CfdiUtils\Validate\Status;
 
-class CreateComprobanteCaseTest extends TestCase
+final class CreateComprobanteCaseTest extends TestCase
 {
     public function testCreateCfdiUsingComprobanteElement()
     {

--- a/tests/CfdiUtilsTests/CreateComprobantePagosCaseTest.php
+++ b/tests/CfdiUtilsTests/CreateComprobantePagosCaseTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\CfdiCreator33;
 use CfdiUtils\Elements\Pagos10\Pagos;
 use CfdiUtils\Utils\Format;
 
-class CreateComprobantePagosCaseTest extends TestCase
+final class CreateComprobantePagosCaseTest extends TestCase
 {
     public function testMoveSatDefinitionsToComprobante()
     {

--- a/tests/CfdiUtilsTests/Elements/Cce11/ComercioExteriorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/ComercioExteriorTest.php
@@ -11,7 +11,7 @@ use CfdiUtils\Elements\Cce11\Propietario;
 use CfdiUtils\Elements\Cce11\Receptor;
 use PHPUnit\Framework\TestCase;
 
-class ComercioExteriorTest extends TestCase
+final class ComercioExteriorTest extends TestCase
 {
     /** @var ComercioExterior */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/ComercioExteriorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/ComercioExteriorTest.php
@@ -16,7 +16,7 @@ class ComercioExteriorTest extends TestCase
     /** @var ComercioExterior */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new ComercioExterior();

--- a/tests/CfdiUtilsTests/Elements/Cce11/DescripcionesEspecificasTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/DescripcionesEspecificasTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cce11;
 use CfdiUtils\Elements\Cce11\DescripcionesEspecificas;
 use PHPUnit\Framework\TestCase;
 
-class DescripcionesEspecificasTest extends TestCase
+final class DescripcionesEspecificasTest extends TestCase
 {
     /** @var DescripcionesEspecificas */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/DescripcionesEspecificasTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/DescripcionesEspecificasTest.php
@@ -10,7 +10,7 @@ class DescripcionesEspecificasTest extends TestCase
     /** @var DescripcionesEspecificas */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new DescripcionesEspecificas();

--- a/tests/CfdiUtilsTests/Elements/Cce11/DestinatarioTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/DestinatarioTest.php
@@ -11,7 +11,7 @@ class DestinatarioTest extends TestCase
     /** @var Destinatario */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Destinatario();

--- a/tests/CfdiUtilsTests/Elements/Cce11/DestinatarioTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/DestinatarioTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cce11\Destinatario;
 use CfdiUtils\Elements\Cce11\Domicilio;
 use PHPUnit\Framework\TestCase;
 
-class DestinatarioTest extends TestCase
+final class DestinatarioTest extends TestCase
 {
     /** @var Destinatario */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/DomicilioTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/DomicilioTest.php
@@ -10,7 +10,7 @@ class DomicilioTest extends TestCase
     /** @var Domicilio */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Domicilio();

--- a/tests/CfdiUtilsTests/Elements/Cce11/DomicilioTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/DomicilioTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cce11;
 use CfdiUtils\Elements\Cce11\Domicilio;
 use PHPUnit\Framework\TestCase;
 
-class DomicilioTest extends TestCase
+final class DomicilioTest extends TestCase
 {
     /** @var Domicilio */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/EmisorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/EmisorTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cce11\Domicilio;
 use CfdiUtils\Elements\Cce11\Emisor;
 use PHPUnit\Framework\TestCase;
 
-class EmisorTest extends TestCase
+final class EmisorTest extends TestCase
 {
     /** @var Emisor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/EmisorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/EmisorTest.php
@@ -11,7 +11,7 @@ class EmisorTest extends TestCase
     /** @var Emisor */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Emisor();

--- a/tests/CfdiUtilsTests/Elements/Cce11/MercanciaTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/MercanciaTest.php
@@ -11,7 +11,7 @@ class MercanciaTest extends TestCase
     /** @var Mercancia */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Mercancia();

--- a/tests/CfdiUtilsTests/Elements/Cce11/MercanciaTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/MercanciaTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cce11\DescripcionesEspecificas;
 use CfdiUtils\Elements\Cce11\Mercancia;
 use PHPUnit\Framework\TestCase;
 
-class MercanciaTest extends TestCase
+final class MercanciaTest extends TestCase
 {
     /** @var Mercancia */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/MercanciasTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/MercanciasTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cce11\Mercancia;
 use CfdiUtils\Elements\Cce11\Mercancias;
 use PHPUnit\Framework\TestCase;
 
-class MercanciasTest extends TestCase
+final class MercanciasTest extends TestCase
 {
     /** @var Mercancias */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/MercanciasTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/MercanciasTest.php
@@ -11,7 +11,7 @@ class MercanciasTest extends TestCase
     /** @var Mercancias */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Mercancias();

--- a/tests/CfdiUtilsTests/Elements/Cce11/ReceptorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/ReceptorTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cce11\Domicilio;
 use CfdiUtils\Elements\Cce11\Receptor;
 use PHPUnit\Framework\TestCase;
 
-class ReceptorTest extends TestCase
+final class ReceptorTest extends TestCase
 {
     /** @var Receptor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/ReceptorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/ReceptorTest.php
@@ -11,7 +11,7 @@ class ReceptorTest extends TestCase
     /** @var Receptor */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Receptor();

--- a/tests/CfdiUtilsTests/Elements/Cce11/Traits/DomicilioTraitTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/Traits/DomicilioTraitTest.php
@@ -10,7 +10,7 @@ class DomicilioTraitTest extends TestCase
     /** @var UseDomicilio */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new UseDomicilio();

--- a/tests/CfdiUtilsTests/Elements/Cce11/Traits/DomicilioTraitTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/Traits/DomicilioTraitTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cce11\Traits;
 use CfdiUtils\Elements\Cce11\Domicilio;
 use PHPUnit\Framework\TestCase;
 
-class DomicilioTraitTest extends TestCase
+final class DomicilioTraitTest extends TestCase
 {
     /** @var UseDomicilio */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cce11/Traits/UseDomicilio.php
+++ b/tests/CfdiUtilsTests/Elements/Cce11/Traits/UseDomicilio.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cce11\Traits;
 use CfdiUtils\Elements\Cce11\Traits\DomicilioTrait;
 use CfdiUtils\Elements\Common\AbstractElement;
 
-class UseDomicilio extends AbstractElement
+final class UseDomicilio extends AbstractElement
 {
     use DomicilioTrait;
 

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/AddendaTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/AddendaTest.php
@@ -11,7 +11,7 @@ class AddendaTest extends TestCase
     /** @var Addenda */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Addenda();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/AddendaTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/AddendaTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cfdi33\Addenda;
 use CfdiUtils\Nodes\Node;
 use PHPUnit\Framework\TestCase;
 
-class AddendaTest extends TestCase
+final class AddendaTest extends TestCase
 {
     /** @var Addenda */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/CfdiRelacionadoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/CfdiRelacionadoTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33;
 use CfdiUtils\Elements\Cfdi33\CfdiRelacionado;
 use PHPUnit\Framework\TestCase;
 
-class CfdiRelacionadoTest extends TestCase
+final class CfdiRelacionadoTest extends TestCase
 {
     /** @var CfdiRelacionado */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/CfdiRelacionadoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/CfdiRelacionadoTest.php
@@ -10,7 +10,7 @@ class CfdiRelacionadoTest extends TestCase
     /** @var CfdiRelacionado */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new CfdiRelacionado();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/CfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/CfdiRelacionadosTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cfdi33\CfdiRelacionado;
 use CfdiUtils\Elements\Cfdi33\CfdiRelacionados;
 use PHPUnit\Framework\TestCase;
 
-class CfdiRelacionadosTest extends TestCase
+final class CfdiRelacionadosTest extends TestCase
 {
     /** @var CfdiRelacionados */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/CfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/CfdiRelacionadosTest.php
@@ -11,7 +11,7 @@ class CfdiRelacionadosTest extends TestCase
     /** @var CfdiRelacionados */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new CfdiRelacionados();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComplementoConceptoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComplementoConceptoTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33;
 use CfdiUtils\Elements\Cfdi33\ComplementoConcepto;
 use PHPUnit\Framework\TestCase;
 
-class ComplementoConceptoTest extends TestCase
+final class ComplementoConceptoTest extends TestCase
 {
     /** @var ComplementoConcepto */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComplementoConceptoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComplementoConceptoTest.php
@@ -10,7 +10,7 @@ class ComplementoConceptoTest extends TestCase
     /** @var ComplementoConcepto */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new ComplementoConcepto();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComplementoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComplementoTest.php
@@ -11,7 +11,7 @@ class ComplementoTest extends TestCase
     /** @var Complemento */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Complemento();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComplementoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComplementoTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cfdi33\Complemento;
 use CfdiUtils\Nodes\Node;
 use PHPUnit\Framework\TestCase;
 
-class ComplementoTest extends TestCase
+final class ComplementoTest extends TestCase
 {
     /** @var Complemento */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
@@ -3,7 +3,6 @@
 namespace CfdiUtilsTests\Elements\Cfdi33;
 
 use CfdiUtils\Elements\Cfdi33\Comprobante;
-use DMS\PHPUnitExtensions\ArraySubset\Assert as ArraySubsetAssert;
 use PHPUnit\Framework\TestCase;
 
 /*
@@ -65,7 +64,17 @@ class ComprobanteGetCfdiRelacionadosTest extends TestCase
             'errstr' => 'El método getCfdiRelacionados ya no admite atributos, use addCfdiRelacionados en su lugar',
         ];
 
-        ArraySubsetAssert::assertArraySubset($expectedError, $this->errors[0]);
+        $capturedError = $this->errors[0] ?? [];
+        $this->assertSame(
+            $expectedError['errno'],
+            $capturedError['errno'] ?? null,
+            'Captured error does not have expected error number'
+        );
+        $this->assertSame(
+            $expectedError['errstr'],
+            $capturedError['errstr'] ?? null,
+            'Captured error does not have expected error message'
+        );
     }
 
     public function testStillIsWorkingWhenPassAnArrayAsArgument()

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
@@ -3,6 +3,7 @@
 namespace CfdiUtilsTests\Elements\Cfdi33;
 
 use CfdiUtils\Elements\Cfdi33\Comprobante;
+use DMS\PHPUnitExtensions\ArraySubset\Assert as ArraySubsetAssert;
 use PHPUnit\Framework\TestCase;
 
 /*
@@ -59,7 +60,7 @@ class ComprobanteGetCfdiRelacionadosTest extends TestCase
             'errstr' => 'El método getCfdiRelacionados ya no admite atributos, use addCfdiRelacionados en su lugar',
         ];
 
-        $this->assertArraySubset($expectedError, $this->errors[0]);
+        ArraySubsetAssert::assertArraySubset($expectedError, $this->errors[0]);
     }
 
     public function testStillIsWorkingWhenPassAnArrayAsArgument()

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  *
  */
 
-class ComprobanteGetCfdiRelacionadosTest extends TestCase
+final class ComprobanteGetCfdiRelacionadosTest extends TestCase
 {
     private $errors = [];
 

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
@@ -36,8 +36,13 @@ class ComprobanteGetCfdiRelacionadosTest extends TestCase
         parent::tearDown();
     }
 
-    public function errorHandler(int $errno, string $errstr, string $errfile = '', int $errline = 0, array $errcontext = []): bool
-    {
+    public function errorHandler(
+        int $errno,
+        string $errstr,
+        string $errfile = '',
+        int $errline = 0,
+        array $errcontext = []
+    ): bool {
         $this->errors[] = compact('errno', 'errstr', 'errfile', 'errline', 'errcontext');
         return true;
     }

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteGetCfdiRelacionadosTest.php
@@ -20,7 +20,7 @@ class ComprobanteGetCfdiRelacionadosTest extends TestCase
 {
     private $errors = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         set_error_handler(
@@ -29,15 +29,16 @@ class ComprobanteGetCfdiRelacionadosTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         restore_error_handler();
         parent::tearDown();
     }
 
-    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext)
+    public function errorHandler(int $errno, string $errstr, string $errfile = '', int $errline = 0, array $errcontext = []): bool
     {
         $this->errors[] = compact('errno', 'errstr', 'errfile', 'errline', 'errcontext');
+        return true;
     }
 
     public function testGetCfdiRelacionadoDontTriggerErrorsWhenCallWithoutArgument()

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteTest.php
@@ -15,7 +15,7 @@ use CfdiUtils\Elements\Cfdi33\Receptor;
 use CfdiUtils\Nodes\Node;
 use PHPUnit\Framework\TestCase;
 
-class ComprobanteTest extends TestCase
+final class ComprobanteTest extends TestCase
 {
     /**@var Comprobante */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ComprobanteTest.php
@@ -20,7 +20,7 @@ class ComprobanteTest extends TestCase
     /**@var Comprobante */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Comprobante();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ConceptoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ConceptoTest.php
@@ -11,7 +11,7 @@ use CfdiUtils\Elements\Cfdi33\InformacionAduanera;
 use CfdiUtils\Elements\Cfdi33\Parte;
 use PHPUnit\Framework\TestCase;
 
-class ConceptoTest extends TestCase
+final class ConceptoTest extends TestCase
 {
     /** @var  Concepto */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ConceptoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ConceptoTest.php
@@ -16,7 +16,7 @@ class ConceptoTest extends TestCase
     /** @var  Concepto */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Concepto();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ConceptosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ConceptosTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cfdi33\Concepto;
 use CfdiUtils\Elements\Cfdi33\Conceptos;
 use PHPUnit\Framework\TestCase;
 
-class ConceptosTest extends TestCase
+final class ConceptosTest extends TestCase
 {
     /** @var Conceptos */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ConceptosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ConceptosTest.php
@@ -11,7 +11,7 @@ class ConceptosTest extends TestCase
     /** @var Conceptos */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Conceptos();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/CuentaPredialTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/CuentaPredialTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33;
 use CfdiUtils\Elements\Cfdi33\CuentaPredial;
 use PHPUnit\Framework\TestCase;
 
-class CuentaPredialTest extends TestCase
+final class CuentaPredialTest extends TestCase
 {
     /** @var CuentaPredial */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/CuentaPredialTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/CuentaPredialTest.php
@@ -10,7 +10,7 @@ class CuentaPredialTest extends TestCase
     /** @var CuentaPredial */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new CuentaPredial();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/EmisorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/EmisorTest.php
@@ -10,7 +10,7 @@ class EmisorTest extends TestCase
     /** @var Emisor */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Emisor();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/EmisorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/EmisorTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33;
 use CfdiUtils\Elements\Cfdi33\Emisor;
 use PHPUnit\Framework\TestCase;
 
-class EmisorTest extends TestCase
+final class EmisorTest extends TestCase
 {
     /** @var Emisor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/Helpers/SumasConceptosWriterTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/Helpers/SumasConceptosWriterTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Nodes\XmlNodeUtils;
 use CfdiUtils\SumasConceptos\SumasConceptos;
 use PHPUnit\Framework\TestCase;
 
-class SumasConceptosWriterTest extends TestCase
+final class SumasConceptosWriterTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ImpuestosOrderTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ImpuestosOrderTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Elements\Cfdi33\ConceptoImpuestos;
 use CfdiUtils\Elements\Cfdi33\Impuestos;
 use PHPUnit\Framework\TestCase;
 
-class ImpuestosOrderTest extends TestCase
+final class ImpuestosOrderTest extends TestCase
 {
     public function testComprobanteImpuestosOrderIsRetencionesTraslados()
     {

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ParteTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ParteTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33;
 use CfdiUtils\Elements\Cfdi33\Parte;
 use PHPUnit\Framework\TestCase;
 
-class ParteTest extends TestCase
+final class ParteTest extends TestCase
 {
     /** @var Parte */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ParteTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ParteTest.php
@@ -10,7 +10,7 @@ class ParteTest extends TestCase
     /** @var Parte */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Parte();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ReceptorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ReceptorTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33;
 use CfdiUtils\Elements\Cfdi33\Receptor;
 use PHPUnit\Framework\TestCase;
 
-class ReceptorTest extends TestCase
+final class ReceptorTest extends TestCase
 {
     /** @var Receptor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/ReceptorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/ReceptorTest.php
@@ -10,7 +10,7 @@ class ReceptorTest extends TestCase
     /** @var Receptor */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Receptor();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/RetencionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/RetencionTest.php
@@ -10,7 +10,7 @@ class RetencionTest extends TestCase
     /** @var Retencion */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Retencion();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/RetencionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/RetencionTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33;
 use CfdiUtils\Elements\Cfdi33\Retencion;
 use PHPUnit\Framework\TestCase;
 
-class RetencionTest extends TestCase
+final class RetencionTest extends TestCase
 {
     /** @var Retencion */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/RetencionesTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cfdi33\Retencion;
 use CfdiUtils\Elements\Cfdi33\Retenciones;
 use PHPUnit\Framework\TestCase;
 
-class RetencionesTest extends TestCase
+final class RetencionesTest extends TestCase
 {
     /** @var Retenciones */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/RetencionesTest.php
@@ -11,7 +11,7 @@ class RetencionesTest extends TestCase
     /** @var Retenciones */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Retenciones();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/ImpuestosTraitTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/ImpuestosTraitTest.php
@@ -9,7 +9,7 @@ use CfdiUtils\Elements\Cfdi33\Traslado;
 use CfdiUtils\Elements\Cfdi33\Traslados;
 use PHPUnit\Framework\TestCase;
 
-class ImpuestosTraitTest extends TestCase
+final class ImpuestosTraitTest extends TestCase
 {
     /** @var UseImpuestos */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/ImpuestosTraitTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/ImpuestosTraitTest.php
@@ -14,7 +14,7 @@ class ImpuestosTraitTest extends TestCase
     /** @var UseImpuestos */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new UseImpuestos();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/InformacionAduaneraTraitTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/InformacionAduaneraTraitTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33\Traits;
 use CfdiUtils\Elements\Cfdi33\InformacionAduanera;
 use PHPUnit\Framework\TestCase;
 
-class InformacionAduaneraTraitTest extends TestCase
+final class InformacionAduaneraTraitTest extends TestCase
 {
     public function testAddInformacionAduanera()
     {

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/UseImpuestos.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/UseImpuestos.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cfdi33\Impuestos;
 use CfdiUtils\Elements\Cfdi33\Traits\ImpuestosTrait;
 use CfdiUtils\Elements\Common\AbstractElement;
 
-class UseImpuestos extends AbstractElement
+final class UseImpuestos extends AbstractElement
 {
     use ImpuestosTrait;
 

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/UseInformacionAduanera.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/Traits/UseInformacionAduanera.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33\Traits;
 use CfdiUtils\Elements\Cfdi33\Traits\InformacionAduaneraTrait;
 use CfdiUtils\Nodes\Node;
 
-class UseInformacionAduanera extends Node
+final class UseInformacionAduanera extends Node
 {
     use InformacionAduaneraTrait;
 }

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/TrasladoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/TrasladoTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Cfdi33;
 use CfdiUtils\Elements\Cfdi33\Traslado;
 use PHPUnit\Framework\TestCase;
 
-class TrasladoTest extends TestCase
+final class TrasladoTest extends TestCase
 {
     /** @var Traslado */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/TrasladoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/TrasladoTest.php
@@ -10,7 +10,7 @@ class TrasladoTest extends TestCase
     /** @var Traslado */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Traslado();

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/TrasladosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/TrasladosTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cfdi33\Traslado;
 use CfdiUtils\Elements\Cfdi33\Traslados;
 use PHPUnit\Framework\TestCase;
 
-class TrasladosTest extends TestCase
+final class TrasladosTest extends TestCase
 {
     /** @var Traslados */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Cfdi33/TrasladosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Cfdi33/TrasladosTest.php
@@ -11,7 +11,7 @@ class TrasladosTest extends TestCase
     /** @var Traslados */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Traslados();

--- a/tests/CfdiUtilsTests/Elements/Dividendos10/DividOUtilTest.php
+++ b/tests/CfdiUtilsTests/Elements/Dividendos10/DividOUtilTest.php
@@ -10,7 +10,7 @@ class DividOUtilTest extends TestCase
     /** @var DividOUtil */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new DividOUtil();

--- a/tests/CfdiUtilsTests/Elements/Dividendos10/DividOUtilTest.php
+++ b/tests/CfdiUtilsTests/Elements/Dividendos10/DividOUtilTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Dividendos10;
 use CfdiUtils\Elements\Dividendos10\DividOUtil;
 use PHPUnit\Framework\TestCase;
 
-class DividOUtilTest extends TestCase
+final class DividOUtilTest extends TestCase
 {
     /** @var DividOUtil */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Dividendos10/DividendosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Dividendos10/DividendosTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Elements\Dividendos10\DividOUtil;
 use CfdiUtils\Elements\Dividendos10\Remanente;
 use PHPUnit\Framework\TestCase;
 
-class DividendosTest extends TestCase
+final class DividendosTest extends TestCase
 {
     /** @var Dividendos */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Dividendos10/DividendosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Dividendos10/DividendosTest.php
@@ -12,7 +12,7 @@ class DividendosTest extends TestCase
     /** @var Dividendos */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Dividendos();

--- a/tests/CfdiUtilsTests/Elements/Dividendos10/RemanenteTest.php
+++ b/tests/CfdiUtilsTests/Elements/Dividendos10/RemanenteTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Dividendos10;
 use CfdiUtils\Elements\Dividendos10\Remanente;
 use PHPUnit\Framework\TestCase;
 
-class RemanenteTest extends TestCase
+final class RemanenteTest extends TestCase
 {
     /** @var Remanente */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Dividendos10/RemanenteTest.php
+++ b/tests/CfdiUtilsTests/Elements/Dividendos10/RemanenteTest.php
@@ -10,7 +10,7 @@ class RemanenteTest extends TestCase
     /** @var Remanente */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Remanente();

--- a/tests/CfdiUtilsTests/Elements/ImpLocal10/ImpuestosLocalesTest.php
+++ b/tests/CfdiUtilsTests/Elements/ImpLocal10/ImpuestosLocalesTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Elements\ImpLocal10\RetencionesLocales;
 use CfdiUtils\Elements\ImpLocal10\TrasladosLocales;
 use PHPUnit\Framework\TestCase;
 
-class ImpuestosLocalesTest extends TestCase
+final class ImpuestosLocalesTest extends TestCase
 {
     /** @var ImpuestosLocales */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/ImpLocal10/ImpuestosLocalesTest.php
+++ b/tests/CfdiUtilsTests/Elements/ImpLocal10/ImpuestosLocalesTest.php
@@ -12,7 +12,7 @@ class ImpuestosLocalesTest extends TestCase
     /** @var ImpuestosLocales */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new ImpuestosLocales();

--- a/tests/CfdiUtilsTests/Elements/ImpLocal10/RetencionesLocalesTest.php
+++ b/tests/CfdiUtilsTests/Elements/ImpLocal10/RetencionesLocalesTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\ImpLocal10;
 use CfdiUtils\Elements\ImpLocal10\RetencionesLocales;
 use PHPUnit\Framework\TestCase;
 
-class RetencionesLocalesTest extends TestCase
+final class RetencionesLocalesTest extends TestCase
 {
     /** @var RetencionesLocales */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/ImpLocal10/RetencionesLocalesTest.php
+++ b/tests/CfdiUtilsTests/Elements/ImpLocal10/RetencionesLocalesTest.php
@@ -10,7 +10,7 @@ class RetencionesLocalesTest extends TestCase
     /** @var RetencionesLocales */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new RetencionesLocales();

--- a/tests/CfdiUtilsTests/Elements/ImpLocal10/TrasladosLocalesTest.php
+++ b/tests/CfdiUtilsTests/Elements/ImpLocal10/TrasladosLocalesTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\ImpLocal10;
 use CfdiUtils\Elements\ImpLocal10\TrasladosLocales;
 use PHPUnit\Framework\TestCase;
 
-class TrasladosLocalesTest extends TestCase
+final class TrasladosLocalesTest extends TestCase
 {
     /** @var TrasladosLocales */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/ImpLocal10/TrasladosLocalesTest.php
+++ b/tests/CfdiUtilsTests/Elements/ImpLocal10/TrasladosLocalesTest.php
@@ -10,7 +10,7 @@ class TrasladosLocalesTest extends TestCase
     /** @var TrasladosLocales */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new TrasladosLocales();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/AccionesOTitulosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/AccionesOTitulosTest.php
@@ -13,7 +13,7 @@ class AccionesOTitulosTest extends TestCase
     /** @var AccionesOTitulos */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new AccionesOTitulos();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/AccionesOTitulosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/AccionesOTitulosTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\AccionesOTitulos
  */
-class AccionesOTitulosTest extends TestCase
+final class AccionesOTitulosTest extends TestCase
 {
     /** @var AccionesOTitulos */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/CompensacionSaldosAFavorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/CompensacionSaldosAFavorTest.php
@@ -13,7 +13,7 @@ class CompensacionSaldosAFavorTest extends TestCase
     /** @var CompensacionSaldosAFavor */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new CompensacionSaldosAFavor();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/CompensacionSaldosAFavorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/CompensacionSaldosAFavorTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\CompensacionSaldosAFavor
  */
-class CompensacionSaldosAFavorTest extends TestCase
+final class CompensacionSaldosAFavorTest extends TestCase
 {
     /** @var CompensacionSaldosAFavor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/DeduccionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/DeduccionTest.php
@@ -13,7 +13,7 @@ class DeduccionTest extends TestCase
     /** @var Deduccion */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Deduccion();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/DeduccionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/DeduccionTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Deduccion
  */
-class DeduccionTest extends TestCase
+final class DeduccionTest extends TestCase
 {
     /** @var Deduccion */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/DeduccionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/DeduccionesTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Deducciones
  */
-class DeduccionesTest extends TestCase
+final class DeduccionesTest extends TestCase
 {
     /** @var Deducciones */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/DeduccionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/DeduccionesTest.php
@@ -14,7 +14,7 @@ class DeduccionesTest extends TestCase
     /** @var Deducciones */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Deducciones();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/EmisorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/EmisorTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Emisor
  */
-class EmisorTest extends TestCase
+final class EmisorTest extends TestCase
 {
     /** @var Emisor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/EmisorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/EmisorTest.php
@@ -14,7 +14,7 @@ class EmisorTest extends TestCase
     /** @var Emisor */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Emisor();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/EntidadSNCFTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/EntidadSNCFTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\EntidadSNCF
  */
-class EntidadSNCFTest extends TestCase
+final class EntidadSNCFTest extends TestCase
 {
     /** @var EntidadSNCF */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/EntidadSNCFTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/EntidadSNCFTest.php
@@ -13,7 +13,7 @@ class EntidadSNCFTest extends TestCase
     /** @var EntidadSNCF */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new EntidadSNCF();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/HorasExtraTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/HorasExtraTest.php
@@ -13,7 +13,7 @@ class HorasExtraTest extends TestCase
     /** @var HorasExtra */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new HorasExtra();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/HorasExtraTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/HorasExtraTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\HorasExtra
  */
-class HorasExtraTest extends TestCase
+final class HorasExtraTest extends TestCase
 {
     /** @var HorasExtra */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/IncapacidadTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/IncapacidadTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Incapacidad
  */
-class IncapacidadTest extends TestCase
+final class IncapacidadTest extends TestCase
 {
     /** @var Incapacidad */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/IncapacidadTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/IncapacidadTest.php
@@ -13,7 +13,7 @@ class IncapacidadTest extends TestCase
     /** @var Incapacidad */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Incapacidad();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/IncapacidadesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/IncapacidadesTest.php
@@ -14,7 +14,7 @@ class IncapacidadesTest extends TestCase
     /** @var Incapacidades */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Incapacidades();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/IncapacidadesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/IncapacidadesTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Incapacidades
  */
-class IncapacidadesTest extends TestCase
+final class IncapacidadesTest extends TestCase
 {
     /** @var Incapacidades */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/JubilacionPensionRetiroTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/JubilacionPensionRetiroTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\JubilacionPensionRetiro
  */
-class JubilacionPensionRetiroTest extends TestCase
+final class JubilacionPensionRetiroTest extends TestCase
 {
     /** @var JubilacionPensionRetiro */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/JubilacionPensionRetiroTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/JubilacionPensionRetiroTest.php
@@ -13,7 +13,7 @@ class JubilacionPensionRetiroTest extends TestCase
     /** @var JubilacionPensionRetiro */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new JubilacionPensionRetiro();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/NominaTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/NominaTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Nomina
  */
-class NominaTest extends TestCase
+final class NominaTest extends TestCase
 {
     /** @var Nomina */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/NominaTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/NominaTest.php
@@ -19,7 +19,7 @@ class NominaTest extends TestCase
     /** @var Nomina */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Nomina();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/OtroPagoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/OtroPagoTest.php
@@ -15,7 +15,7 @@ class OtroPagoTest extends TestCase
     /** @var OtroPago */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new OtroPago();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/OtroPagoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/OtroPagoTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\OtroPago
  */
-class OtroPagoTest extends TestCase
+final class OtroPagoTest extends TestCase
 {
     /** @var OtroPago */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/OtrosPagosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/OtrosPagosTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\OtrosPagos
  */
-class OtrosPagosTest extends TestCase
+final class OtrosPagosTest extends TestCase
 {
     /** @var OtrosPagos */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/OtrosPagosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/OtrosPagosTest.php
@@ -14,7 +14,7 @@ class OtrosPagosTest extends TestCase
     /** @var OtrosPagos */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new OtrosPagos();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/PercepcionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/PercepcionTest.php
@@ -16,7 +16,7 @@ class PercepcionTest extends TestCase
     /** @var Percepcion */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Percepcion();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/PercepcionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/PercepcionTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Percepcion
  */
-class PercepcionTest extends TestCase
+final class PercepcionTest extends TestCase
 {
     /** @var Percepcion */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/PercepcionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/PercepcionesTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Percepciones
  */
-class PercepcionesTest extends TestCase
+final class PercepcionesTest extends TestCase
 {
     /** @var Percepciones */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/PercepcionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/PercepcionesTest.php
@@ -17,7 +17,7 @@ class PercepcionesTest extends TestCase
     /** @var Percepciones */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Percepciones();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/ReceptorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/ReceptorTest.php
@@ -14,7 +14,7 @@ class ReceptorTest extends TestCase
     /** @var Receptor */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Receptor();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/ReceptorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/ReceptorTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\Receptor
  */
-class ReceptorTest extends TestCase
+final class ReceptorTest extends TestCase
 {
     /** @var Receptor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/SeparacionIndemnizacionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/SeparacionIndemnizacionTest.php
@@ -13,7 +13,7 @@ class SeparacionIndemnizacionTest extends TestCase
     /** @var SeparacionIndemnizacion */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new SeparacionIndemnizacion();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/SeparacionIndemnizacionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/SeparacionIndemnizacionTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\SeparacionIndemnizacion
  */
-class SeparacionIndemnizacionTest extends TestCase
+final class SeparacionIndemnizacionTest extends TestCase
 {
     /** @var SeparacionIndemnizacion */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/SubContratacionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/SubContratacionTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\SubContratacion
  */
-class SubContratacionTest extends TestCase
+final class SubContratacionTest extends TestCase
 {
     /** @var SubContratacion */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Nomina12/SubContratacionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/SubContratacionTest.php
@@ -13,7 +13,7 @@ class SubContratacionTest extends TestCase
     /** @var SubContratacion */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new SubContratacion();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/SubsidioAlEmpleoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/SubsidioAlEmpleoTest.php
@@ -13,7 +13,7 @@ class SubsidioAlEmpleoTest extends TestCase
     /** @var SubsidioAlEmpleo */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new SubsidioAlEmpleo();

--- a/tests/CfdiUtilsTests/Elements/Nomina12/SubsidioAlEmpleoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Nomina12/SubsidioAlEmpleoTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \CfdiUtils\Elements\Nomina12\SubsidioAlEmpleo
  */
-class SubsidioAlEmpleoTest extends TestCase
+final class SubsidioAlEmpleoTest extends TestCase
 {
     /** @var SubsidioAlEmpleo */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/DoctoRelacionadoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/DoctoRelacionadoTest.php
@@ -10,7 +10,7 @@ class DoctoRelacionadoTest extends TestCase
     /** @var DoctoRelacionado */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new DoctoRelacionado();

--- a/tests/CfdiUtilsTests/Elements/Pagos10/DoctoRelacionadoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/DoctoRelacionadoTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Pagos10;
 use CfdiUtils\Elements\Pagos10\DoctoRelacionado;
 use PHPUnit\Framework\TestCase;
 
-class DoctoRelacionadoTest extends TestCase
+final class DoctoRelacionadoTest extends TestCase
 {
     /** @var DoctoRelacionado */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/ImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/ImpuestosTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Elements\Pagos10\Retenciones;
 use CfdiUtils\Elements\Pagos10\Traslados;
 use PHPUnit\Framework\TestCase;
 
-class ImpuestosTest extends TestCase
+final class ImpuestosTest extends TestCase
 {
     /** @var Impuestos */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/ImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/ImpuestosTest.php
@@ -12,7 +12,7 @@ class ImpuestosTest extends TestCase
     /** @var Impuestos */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Impuestos();

--- a/tests/CfdiUtilsTests/Elements/Pagos10/PagoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/PagoTest.php
@@ -12,7 +12,7 @@ class PagoTest extends TestCase
     /** @var Pago */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Pago();

--- a/tests/CfdiUtilsTests/Elements/Pagos10/PagoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/PagoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Elements\Pagos10\Impuestos;
 use CfdiUtils\Elements\Pagos10\Pago;
 use PHPUnit\Framework\TestCase;
 
-class PagoTest extends TestCase
+final class PagoTest extends TestCase
 {
     /** @var Pago */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/PagosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/PagosTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Pagos10\Pago;
 use CfdiUtils\Elements\Pagos10\Pagos;
 use PHPUnit\Framework\TestCase;
 
-class PagosTest extends TestCase
+final class PagosTest extends TestCase
 {
     /** @var Pagos */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/PagosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/PagosTest.php
@@ -11,7 +11,7 @@ class PagosTest extends TestCase
     /** @var Pagos */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Pagos();

--- a/tests/CfdiUtilsTests/Elements/Pagos10/RetencionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/RetencionTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Pagos10;
 use CfdiUtils\Elements\Pagos10\Retencion;
 use PHPUnit\Framework\TestCase;
 
-class RetencionTest extends TestCase
+final class RetencionTest extends TestCase
 {
     /** @var Retencion */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/RetencionTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/RetencionTest.php
@@ -10,7 +10,7 @@ class RetencionTest extends TestCase
     /** @var Retencion */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Retencion();

--- a/tests/CfdiUtilsTests/Elements/Pagos10/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/RetencionesTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Pagos10\Retencion;
 use CfdiUtils\Elements\Pagos10\Retenciones;
 use PHPUnit\Framework\TestCase;
 
-class RetencionesTest extends TestCase
+final class RetencionesTest extends TestCase
 {
     /** @var Retenciones */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/RetencionesTest.php
@@ -11,7 +11,7 @@ class RetencionesTest extends TestCase
     /** @var Retenciones */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Retenciones();

--- a/tests/CfdiUtilsTests/Elements/Pagos10/TrasladoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/TrasladoTest.php
@@ -10,7 +10,7 @@ class TrasladoTest extends TestCase
     /** @var Traslado */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Traslado();

--- a/tests/CfdiUtilsTests/Elements/Pagos10/TrasladoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/TrasladoTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Pagos10;
 use CfdiUtils\Elements\Pagos10\Traslado;
 use PHPUnit\Framework\TestCase;
 
-class TrasladoTest extends TestCase
+final class TrasladoTest extends TestCase
 {
     /** @var Traslado */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/TrasladosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/TrasladosTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Pagos10\Traslado;
 use CfdiUtils\Elements\Pagos10\Traslados;
 use PHPUnit\Framework\TestCase;
 
-class TrasladosTest extends TestCase
+final class TrasladosTest extends TestCase
 {
     /** @var Traslados */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Pagos10/TrasladosTest.php
+++ b/tests/CfdiUtilsTests/Elements/Pagos10/TrasladosTest.php
@@ -11,7 +11,7 @@ class TrasladosTest extends TestCase
     /** @var Traslados */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Traslados();

--- a/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/BeneficiarioTest.php
+++ b/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/BeneficiarioTest.php
@@ -10,7 +10,7 @@ class BeneficiarioTest extends TestCase
     /** @var Beneficiario */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Beneficiario();

--- a/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/BeneficiarioTest.php
+++ b/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/BeneficiarioTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\PagosAExtranjeros10;
 use CfdiUtils\Elements\PagosAExtranjeros10\Beneficiario;
 use PHPUnit\Framework\TestCase;
 
-class BeneficiarioTest extends TestCase
+final class BeneficiarioTest extends TestCase
 {
     /** @var Beneficiario */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/NoBeneficiarioTest.php
+++ b/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/NoBeneficiarioTest.php
@@ -10,7 +10,7 @@ class NoBeneficiarioTest extends TestCase
     /** @var NoBeneficiario */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new NoBeneficiario();

--- a/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/NoBeneficiarioTest.php
+++ b/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/NoBeneficiarioTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\PagosAExtranjeros10;
 use CfdiUtils\Elements\PagosAExtranjeros10\NoBeneficiario;
 use PHPUnit\Framework\TestCase;
 
-class NoBeneficiarioTest extends TestCase
+final class NoBeneficiarioTest extends TestCase
 {
     /** @var NoBeneficiario */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/PagosaextranjerosTest.php
+++ b/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/PagosaextranjerosTest.php
@@ -12,7 +12,7 @@ class PagosaextranjerosTest extends TestCase
     /** @var Pagosaextranjeros */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Pagosaextranjeros();

--- a/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/PagosaextranjerosTest.php
+++ b/tests/CfdiUtilsTests/Elements/PagosAExtranjeros10/PagosaextranjerosTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Elements\PagosAExtranjeros10\NoBeneficiario;
 use CfdiUtils\Elements\PagosAExtranjeros10\Pagosaextranjeros;
 use PHPUnit\Framework\TestCase;
 
-class PagosaextranjerosTest extends TestCase
+final class PagosaextranjerosTest extends TestCase
 {
     /** @var Pagosaextranjeros */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/AddendaTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/AddendaTest.php
@@ -11,7 +11,7 @@ class AddendaTest extends TestCase
     /** @var Addenda */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Addenda();

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/AddendaTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/AddendaTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Retenciones10\Addenda;
 use CfdiUtils\Nodes\Node;
 use PHPUnit\Framework\TestCase;
 
-class AddendaTest extends TestCase
+final class AddendaTest extends TestCase
 {
     /** @var Addenda */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/ComplementoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/ComplementoTest.php
@@ -11,7 +11,7 @@ class ComplementoTest extends TestCase
     /** @var Complemento */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Complemento();

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/ComplementoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/ComplementoTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Retenciones10\Complemento;
 use CfdiUtils\Nodes\Node;
 use PHPUnit\Framework\TestCase;
 
-class ComplementoTest extends TestCase
+final class ComplementoTest extends TestCase
 {
     /** @var Complemento */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/EmisorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/EmisorTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Retenciones10;
 use CfdiUtils\Elements\Retenciones10\Emisor;
 use PHPUnit\Framework\TestCase;
 
-class EmisorTest extends TestCase
+final class EmisorTest extends TestCase
 {
     /** @var Emisor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/EmisorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/EmisorTest.php
@@ -10,7 +10,7 @@ class EmisorTest extends TestCase
     /** @var Emisor */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Emisor();

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/PeriodoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/PeriodoTest.php
@@ -10,7 +10,7 @@ class PeriodoTest extends TestCase
     /** @var Periodo */
     public $element;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->element = new Periodo();

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/PeriodoTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/PeriodoTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Elements\Retenciones10;
 use CfdiUtils\Elements\Retenciones10\Periodo;
 use PHPUnit\Framework\TestCase;
 
-class PeriodoTest extends TestCase
+final class PeriodoTest extends TestCase
 {
     /** @var Periodo */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/ReceptorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/ReceptorTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Elements\Retenciones10\Nacional;
 use CfdiUtils\Elements\Retenciones10\Receptor;
 use PHPUnit\Framework\TestCase;
 
-class ReceptorTest extends TestCase
+final class ReceptorTest extends TestCase
 {
     /** @var Receptor */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/ReceptorTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/ReceptorTest.php
@@ -12,7 +12,7 @@ class ReceptorTest extends TestCase
     /** @var Receptor */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Receptor();

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/RetencionesTest.php
@@ -13,7 +13,7 @@ use CfdiUtils\Elements\Retenciones10\Totales;
 use CfdiUtils\Nodes\Node;
 use PHPUnit\Framework\TestCase;
 
-class RetencionesTest extends TestCase
+final class RetencionesTest extends TestCase
 {
     /** @var Retenciones */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/RetencionesTest.php
@@ -18,7 +18,7 @@ class RetencionesTest extends TestCase
     /** @var Retenciones */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Retenciones();

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/TotalesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/TotalesTest.php
@@ -11,7 +11,7 @@ class TotalesTest extends TestCase
     /** @var Totales */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new Totales();

--- a/tests/CfdiUtilsTests/Elements/Retenciones10/TotalesTest.php
+++ b/tests/CfdiUtilsTests/Elements/Retenciones10/TotalesTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Retenciones10\ImpRetenidos;
 use CfdiUtils\Elements\Retenciones10\Totales;
 use PHPUnit\Framework\TestCase;
 
-class TotalesTest extends TestCase
+final class TotalesTest extends TestCase
 {
     /** @var Totales */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Tfd11/TimbreFiscalDigitalTest.php
+++ b/tests/CfdiUtilsTests/Elements/Tfd11/TimbreFiscalDigitalTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Cfdi33\Comprobante;
 use CfdiUtils\Elements\Tfd11\TimbreFiscalDigital;
 use PHPUnit\Framework\TestCase;
 
-class TimbreFiscalDigitalTest extends TestCase
+final class TimbreFiscalDigitalTest extends TestCase
 {
     /**@var Comprobante */
     public $element;

--- a/tests/CfdiUtilsTests/Elements/Tfd11/TimbreFiscalDigitalTest.php
+++ b/tests/CfdiUtilsTests/Elements/Tfd11/TimbreFiscalDigitalTest.php
@@ -11,7 +11,7 @@ class TimbreFiscalDigitalTest extends TestCase
     /**@var Comprobante */
     public $element;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new TimbreFiscalDigital();

--- a/tests/CfdiUtilsTests/Internals/BaseConverterSequenceTest.php
+++ b/tests/CfdiUtilsTests/Internals/BaseConverterSequenceTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Internals;
 use CfdiUtils\Internals\BaseConverterSequence;
 use PHPUnit\Framework\TestCase;
 
-class BaseConverterSequenceTest extends TestCase
+final class BaseConverterSequenceTest extends TestCase
 {
     public function testValidSequence()
     {

--- a/tests/CfdiUtilsTests/Internals/BaseConverterTest.php
+++ b/tests/CfdiUtilsTests/Internals/BaseConverterTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Internals\BaseConverter;
 use CfdiUtils\Internals\BaseConverterSequence;
 use PHPUnit\Framework\TestCase;
 
-class BaseConverterTest extends TestCase
+final class BaseConverterTest extends TestCase
 {
     public function testBasicFunctionality()
     {

--- a/tests/CfdiUtilsTests/Internals/FakeShellExec.php
+++ b/tests/CfdiUtilsTests/Internals/FakeShellExec.php
@@ -8,7 +8,7 @@ use CfdiUtils\Internals\ShellExecResult;
 /**
  * Use this class to emulate a ShellExec with predefined result
  */
-class FakeShellExec extends ShellExec
+final class FakeShellExec extends ShellExec
 {
     /** @var ShellExecResult|null */
     private $result;

--- a/tests/CfdiUtilsTests/Internals/ShellExecTemplateTest.php
+++ b/tests/CfdiUtilsTests/Internals/ShellExecTemplateTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Internals;
 use CfdiUtils\Internals\ShellExecTemplate;
 use CfdiUtilsTests\TestCase;
 
-class ShellExecTemplateTest extends TestCase
+final class ShellExecTemplateTest extends TestCase
 {
     public function providerTemplateCommandToArrayArguments(): array
     {

--- a/tests/CfdiUtilsTests/Internals/ShellExecTemplateTest.php
+++ b/tests/CfdiUtilsTests/Internals/ShellExecTemplateTest.php
@@ -7,7 +7,7 @@ use CfdiUtilsTests\TestCase;
 
 class ShellExecTemplateTest extends TestCase
 {
-    public function providerTemplateCommandToArrayArguments()
+    public function providerTemplateCommandToArrayArguments(): array
     {
         return [
             'first argument' => ['? fire', ['command'], ['command', 'fire']],

--- a/tests/CfdiUtilsTests/Internals/ShellExecTest.php
+++ b/tests/CfdiUtilsTests/Internals/ShellExecTest.php
@@ -86,7 +86,7 @@ class ShellExecTest extends TestCase
         $execution = (new ShellExec($command))->run();
 
         $expectedContent = basename(__FILE__);
-        $this->assertContains($expectedContent, $execution->output());
+        $this->assertStringContainsString($expectedContent, $execution->output());
     }
 
     public function testRunExpectingExitStatus()
@@ -141,7 +141,7 @@ class ShellExecTest extends TestCase
         $this->assertSame('value of foo / value of bar', $execution->output());
     }
 
-    public function providerEnvironmentVariablePathDoesNotGetLost()
+    public function providerEnvironmentVariablePathDoesNotGetLost(): array
     {
         return [
             'with one environment var' => [['foo' => 'bar']],

--- a/tests/CfdiUtilsTests/Internals/ShellExecTest.php
+++ b/tests/CfdiUtilsTests/Internals/ShellExecTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Internals;
 use CfdiUtils\Internals\ShellExec;
 use PHPUnit\Framework\TestCase;
 
-class ShellExecTest extends TestCase
+final class ShellExecTest extends TestCase
 {
     public function testConstructWithValues()
     {

--- a/tests/CfdiUtilsTests/Internals/TemporaryFileTest.php
+++ b/tests/CfdiUtilsTests/Internals/TemporaryFileTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Internals;
 use CfdiUtils\Internals\TemporaryFile;
 use CfdiUtilsTests\TestCase;
 
-class TemporaryFileTest extends TestCase
+final class TemporaryFileTest extends TestCase
 {
     public function testBasicFunctionality()
     {

--- a/tests/CfdiUtilsTests/Internals/TemporaryFileTest.php
+++ b/tests/CfdiUtilsTests/Internals/TemporaryFileTest.php
@@ -12,7 +12,7 @@ final class TemporaryFileTest extends TestCase
         $temp = TemporaryFile::create();
         $this->assertFileExists($temp->getPath());
         $temp->remove();
-        $this->assertFileNotExists($temp->getPath());
+        $this->assertFileDoesNotExist($temp->getPath());
     }
 
     public function testCreateWithDirectory()
@@ -90,7 +90,7 @@ final class TemporaryFileTest extends TestCase
         });
 
         $this->assertSame($expected, $retrieved, 'Method did not return the expected value');
-        $this->assertFileNotExists($file->getPath());
+        $this->assertFileDoesNotExist($file->getPath());
     }
 
     public function testRunAndRemoveWithException()
@@ -107,6 +107,6 @@ final class TemporaryFileTest extends TestCase
             }
         }
 
-        $this->assertFileNotExists($file->getPath());
+        $this->assertFileDoesNotExist($file->getPath());
     }
 }

--- a/tests/CfdiUtilsTests/Internals/TemporaryFileTest.php
+++ b/tests/CfdiUtilsTests/Internals/TemporaryFileTest.php
@@ -45,7 +45,6 @@ class TemporaryFileTest extends TestCase
         if (is_writable($directory)) {
             rmdir($directory);
             $this->markTestSkipped('Cannot create a read-only directory');
-            return;
         }
 
         // setup expected exception

--- a/tests/CfdiUtilsTests/Nodes/AttributesTest.php
+++ b/tests/CfdiUtilsTests/Nodes/AttributesTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Nodes;
 use CfdiUtils\Nodes\Attributes;
 use CfdiUtilsTests\TestCase;
 
-class AttributesTest extends TestCase
+final class AttributesTest extends TestCase
 {
     public function testConstructWithoutArguments()
     {

--- a/tests/CfdiUtilsTests/Nodes/AttributesTest.php
+++ b/tests/CfdiUtilsTests/Nodes/AttributesTest.php
@@ -27,7 +27,7 @@ class AttributesTest extends TestCase
         }
     }
 
-    public function providerSetMethodWithInvalidName()
+    public function providerSetMethodWithInvalidName(): array
     {
         return [
             'empty' => [''],
@@ -63,7 +63,7 @@ class AttributesTest extends TestCase
         $this->assertSame('BAR', $attributes->get('foo'));
     }
 
-    public function providerSetWithInvalidNames()
+    public function providerSetWithInvalidNames(): array
     {
         return [
             'empty' => [''],
@@ -80,7 +80,7 @@ class AttributesTest extends TestCase
      * @param string $name
      * @dataProvider providerSetWithInvalidNames
      */
-    public function testSetWithInvalidNames($name)
+    public function testSetWithInvalidNames(string $name)
     {
         $attributes = new Attributes();
 
@@ -198,7 +198,7 @@ class AttributesTest extends TestCase
                 $this->value = $value;
             }
 
-            public function __toString()
+            public function __toString(): string
             {
                 return $this->value;
             }

--- a/tests/CfdiUtilsTests/Nodes/NodeNsDefinitionsMoverTest.php
+++ b/tests/CfdiUtilsTests/Nodes/NodeNsDefinitionsMoverTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Nodes\NodeNsDefinitionsMover;
 use CfdiUtils\Nodes\XmlNodeUtils;
 use CfdiUtilsTests\TestCase;
 
-class NodeNsDefinitionsMoverTest extends TestCase
+final class NodeNsDefinitionsMoverTest extends TestCase
 {
     public function testMoveDefinitionsWithFilter()
     {

--- a/tests/CfdiUtilsTests/Nodes/NodeTest.php
+++ b/tests/CfdiUtilsTests/Nodes/NodeTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Nodes;
 use CfdiUtils\Nodes\Node;
 use CfdiUtilsTests\TestCase;
 
-class NodeTest extends TestCase
+final class NodeTest extends TestCase
 {
     public function testConstructWithoutArguments()
     {

--- a/tests/CfdiUtilsTests/Nodes/NodesSorterTest.php
+++ b/tests/CfdiUtilsTests/Nodes/NodesSorterTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Nodes\Node;
 use CfdiUtils\Nodes\NodesSorter;
 use PHPUnit\Framework\TestCase;
 
-class NodesSorterTest extends TestCase
+final class NodesSorterTest extends TestCase
 {
     public function testConstructWithNames()
     {

--- a/tests/CfdiUtilsTests/Nodes/NodesTest.php
+++ b/tests/CfdiUtilsTests/Nodes/NodesTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Nodes\NodeInterface;
 use CfdiUtils\Nodes\Nodes;
 use CfdiUtilsTests\TestCase;
 
-class NodesTest extends TestCase
+final class NodesTest extends TestCase
 {
     public function testEmptyNodes()
     {

--- a/tests/CfdiUtilsTests/Nodes/XmlNodeUtilsTest.php
+++ b/tests/CfdiUtilsTests/Nodes/XmlNodeUtilsTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Nodes\XmlNodeUtils;
 use CfdiUtils\Utils\Xml;
 use CfdiUtilsTests\TestCase;
 
-class XmlNodeUtilsTest extends TestCase
+final class XmlNodeUtilsTest extends TestCase
 {
     public function providerToNodeFromNode(): array
     {

--- a/tests/CfdiUtilsTests/Nodes/XmlNodeUtilsTest.php
+++ b/tests/CfdiUtilsTests/Nodes/XmlNodeUtilsTest.php
@@ -78,7 +78,6 @@ class XmlNodeUtilsTest extends TestCase
         $inspected = $node->searchNode('base:Third', 'innerNS');
         if (null === $inspected) {
             $this->fail('The specimen does not have the required test case');
-            return;
         }
         $this->assertSame('http://external.com/inner', $inspected['xmlns']);
     }

--- a/tests/CfdiUtilsTests/Nodes/XmlNodeUtilsTest.php
+++ b/tests/CfdiUtilsTests/Nodes/XmlNodeUtilsTest.php
@@ -9,7 +9,7 @@ use CfdiUtilsTests\TestCase;
 
 class XmlNodeUtilsTest extends TestCase
 {
-    public function providerToNodeFromNode()
+    public function providerToNodeFromNode(): array
     {
         return [
             'simple-xml' => [$this->utilAsset('nodes/sample.xml')],
@@ -35,7 +35,7 @@ class XmlNodeUtilsTest extends TestCase
      * @param string $filename
      * @dataProvider providerToNodeFromNode
      */
-    public function testExportFromFileAndExportAgain($filename)
+    public function testExportFromFileAndExportAgain(string $filename)
     {
         $source = strval(file_get_contents($filename));
 

--- a/tests/CfdiUtilsTests/OpenSSL/CallerTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/CallerTest.php
@@ -10,7 +10,7 @@ use CfdiUtils\OpenSSL\OpenSSLException;
 use CfdiUtilsTests\Internals\FakeShellExec;
 use CfdiUtilsTests\TestCase;
 
-class CallerTest extends TestCase
+final class CallerTest extends TestCase
 {
     public function testConstructWithoutArguments()
     {

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLPropertyTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLPropertyTest.php
@@ -29,6 +29,7 @@ class OpenSSLPropertyTest extends TestCase
         };
 
         $this->expectException(\TypeError::class);
+        /** @noinspection PhpExpressionResultUnusedInspection */
         $object->getOpenSSL();
     }
 

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLPropertyTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLPropertyTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\OpenSSL\OpenSSL;
 use CfdiUtils\OpenSSL\OpenSSLPropertyTrait;
 use CfdiUtilsTests\TestCase;
 
-class OpenSSLPropertyTest extends TestCase
+final class OpenSSLPropertyTest extends TestCase
 {
     public function testCorrectImplementer()
     {

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckInputFileTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckInputFileTest.php
@@ -8,7 +8,7 @@ use CfdiUtilsTests\TestCase;
 
 class OpenSSLProtectedMethodCheckInputFileTest extends TestCase
 {
-    private function openSSL()
+    private function openSSL(): object
     {
         return new class() extends OpenSSL {
             public function checkInputFile(string $path)

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckInputFileTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckInputFileTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Internals\TemporaryFile;
 use CfdiUtils\OpenSSL\OpenSSL;
 use CfdiUtilsTests\TestCase;
 
-class OpenSSLProtectedMethodCheckInputFileTest extends TestCase
+final class OpenSSLProtectedMethodCheckInputFileTest extends TestCase
 {
     private function openSSL(): object
     {

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckOutputFileTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckOutputFileTest.php
@@ -8,7 +8,7 @@ use CfdiUtilsTests\TestCase;
 
 class OpenSSLProtectedMethodCheckOutputFileTest extends TestCase
 {
-    private function openSSL()
+    private function openSSL(): object
     {
         return new class() extends OpenSSL {
             public function checkOutputFile(string $path)

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckOutputFileTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckOutputFileTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Internals\TemporaryFile;
 use CfdiUtils\OpenSSL\OpenSSL;
 use CfdiUtilsTests\TestCase;
 
-class OpenSSLProtectedMethodCheckOutputFileTest extends TestCase
+final class OpenSSLProtectedMethodCheckOutputFileTest extends TestCase
 {
     private function openSSL(): object
     {

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLTest.php
@@ -77,7 +77,7 @@ class OpenSSLTest extends TestCase
         $openssl->derKeyConvertOut($cerFile, 'invalid-passphrase');
     }
 
-    public function providerPrivateKeyProtectPem()
+    public function providerPrivateKeyProtectPem(): array
     {
         return [
             'protect' => ['certs/CSD01_AAA010101AAA.key.pem', '', 'foo-bar-baz'],

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\OpenSSL\OpenSSLCallerException;
 use CfdiUtils\PemPrivateKey\PemPrivateKey;
 use CfdiUtilsTests\TestCase;
 
-class OpenSSLTest extends TestCase
+final class OpenSSLTest extends TestCase
 {
     public function testCreateInstanceWithoutAnyArguments()
     {

--- a/tests/CfdiUtilsTests/OpenSSL/PemExtractorTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/PemExtractorTest.php
@@ -9,14 +9,14 @@ class PemExtractorTest extends TestCase
 {
     public function testExtractorWithEmptyContent()
     {
-        $extractor = new \CfdiUtils\OpenSSL\PemExtractor('');
+        $extractor = new PemExtractor('');
         $this->assertSame('', $extractor->getContents());
         $this->assertSame('', $extractor->extractCertificate());
         $this->assertSame('', $extractor->extractPublicKey());
         $this->assertSame('', $extractor->extractCertificate());
     }
 
-    public function providerCrLfAndLf()
+    public function providerCrLfAndLf(): array
     {
         return [
             'CRLF' => ["\r\n"],
@@ -46,19 +46,19 @@ class PemExtractorTest extends TestCase
             'FOO+PRIVATE+KEY',
             '-----END PRIVATE KEY-----',
         ]);
-        $extractor = new \CfdiUtils\OpenSSL\PemExtractor($content);
+        $extractor = new PemExtractor($content);
         $this->assertSame($content, $extractor->getContents());
-        $this->assertContains(
+        $this->assertStringContainsString(
             'FOO+CERTIFICATE',
             $extractor->extractCertificate(),
             "Certificate using EOL $info was not extracted"
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'FOO+PUBLIC+KEY',
             $extractor->extractPublicKey(),
             "Public Key using EOL $info was not extracted"
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'FOO+PRIVATE+KEY',
             $extractor->extractPrivateKey(),
             "Private Key using EOL $info was not extracted"
@@ -70,11 +70,11 @@ class PemExtractorTest extends TestCase
         $pemcerpub = $this->utilAsset('certs/CSD01_AAA010101AAA.cer.pem');
         $contents = strval(file_get_contents($pemcerpub));
 
-        $extractor = new \CfdiUtils\OpenSSL\PemExtractor($contents);
+        $extractor = new PemExtractor($contents);
         $this->assertSame($contents, $extractor->getContents());
 
-        $this->assertContains('PUBLIC KEY', $extractor->extractPublicKey());
-        $this->assertContains('CERTIFICATE', $extractor->extractCertificate());
+        $this->assertStringContainsString('PUBLIC KEY', $extractor->extractPublicKey());
+        $this->assertStringContainsString('CERTIFICATE', $extractor->extractCertificate());
     }
 
     public function testExtractPrivateKey()
@@ -82,8 +82,8 @@ class PemExtractorTest extends TestCase
         $pemkey = $this->utilAsset('certs/CSD01_AAA010101AAA.key.pem');
         $contents = strval(file_get_contents($pemkey));
 
-        $extractor = new \CfdiUtils\OpenSSL\PemExtractor($contents);
-        $this->assertContains('PRIVATE KEY', $extractor->extractPrivateKey());
+        $extractor = new PemExtractor($contents);
+        $this->assertStringContainsString('PRIVATE KEY', $extractor->extractPrivateKey());
     }
 
     public function testUsingBinaryFileExtractNothing()

--- a/tests/CfdiUtilsTests/OpenSSL/PemExtractorTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/PemExtractorTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\OpenSSL;
 use CfdiUtils\OpenSSL\PemExtractor;
 use CfdiUtilsTests\TestCase;
 
-class PemExtractorTest extends TestCase
+final class PemExtractorTest extends TestCase
 {
     public function testExtractorWithEmptyContent()
     {

--- a/tests/CfdiUtilsTests/PemPrivateKey/PemPrivateKeyTest.php
+++ b/tests/CfdiUtilsTests/PemPrivateKey/PemPrivateKeyTest.php
@@ -8,7 +8,7 @@ use CfdiUtilsTests\TestCase;
 
 class PemPrivateKeyTest extends TestCase
 {
-    public function providerConstructWithBadArgument()
+    public function providerConstructWithBadArgument(): array
     {
         return [
             'empty' => [''],
@@ -29,7 +29,7 @@ class PemPrivateKeyTest extends TestCase
      * @param string $key
      * @dataProvider providerConstructWithBadArgument
      */
-    public function testConstructWithBadArgument($key)
+    public function testConstructWithBadArgument(string $key)
     {
         $this->expectException(\UnexpectedValueException::class);
         new PemPrivateKey($key);

--- a/tests/CfdiUtilsTests/PemPrivateKey/PemPrivateKeyTest.php
+++ b/tests/CfdiUtilsTests/PemPrivateKey/PemPrivateKeyTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Certificado\Certificado;
 use CfdiUtils\PemPrivateKey\PemPrivateKey;
 use CfdiUtilsTests\TestCase;
 
-class PemPrivateKeyTest extends TestCase
+final class PemPrivateKeyTest extends TestCase
 {
     public function providerConstructWithBadArgument(): array
     {

--- a/tests/CfdiUtilsTests/QuickReader/QuickReaderImporterTest.php
+++ b/tests/CfdiUtilsTests/QuickReader/QuickReaderImporterTest.php
@@ -8,7 +8,7 @@ use DOMDocument;
 
 use PHPUnit\Framework\TestCase;
 
-class QuickReaderImporterTest extends TestCase
+final class QuickReaderImporterTest extends TestCase
 {
     public function testImporterImportEmptyNode()
     {

--- a/tests/CfdiUtilsTests/QuickReader/QuickReaderTest.php
+++ b/tests/CfdiUtilsTests/QuickReader/QuickReaderTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\QuickReader\QuickReader;
 
 use PHPUnit\Framework\TestCase;
 
-class QuickReaderTest extends TestCase
+final class QuickReaderTest extends TestCase
 {
     public function testMinimalInstance()
     {

--- a/tests/CfdiUtilsTests/Retenciones/RetencionesCreator10Test.php
+++ b/tests/CfdiUtilsTests/Retenciones/RetencionesCreator10Test.php
@@ -8,7 +8,7 @@ use CfdiUtils\Elements\Dividendos10\Dividendos;
 use CfdiUtils\Retenciones\RetencionesCreator10;
 use CfdiUtilsTests\TestCase;
 
-class RetencionesCreator10Test extends TestCase
+final class RetencionesCreator10Test extends TestCase
 {
     public function testCreatePreCfdiWithAllCorrectValues()
     {

--- a/tests/CfdiUtilsTests/Retenciones/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Retenciones/RetencionesTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Retenciones\Retenciones;
 use CfdiUtils\Utils\Xml;
 use CfdiUtilsTests\TestCase;
 
-class RetencionesTest extends TestCase
+final class RetencionesTest extends TestCase
 {
     const XML_MINIMAL_DEFINITION = <<<XML
 <retenciones:Retenciones xmlns:retenciones="http://www.sat.gob.mx/esquemas/retencionpago/1" Version="1.0"/>

--- a/tests/CfdiUtilsTests/Retenciones/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Retenciones/RetencionesTest.php
@@ -120,7 +120,7 @@ XML;
         $retrieved = $retencion->getDocument();
 
         $this->assertNotSame($document, $retrieved, 'The DOM Document must NOT be the same as constructed');
-        $this->assertXmlStringEqualsXmlString($document, $retrieved, 'The DOM Documents should be equal');
+        $this->assertXmlStringEqualsXmlString($xml, $retrieved->saveXML(), 'The DOM Documents should be equal');
     }
 
     public function testGetSource()

--- a/tests/CfdiUtilsTests/SumasConceptos/SumasConceptosTest.php
+++ b/tests/CfdiUtilsTests/SumasConceptos/SumasConceptosTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Nodes\Node;
 use CfdiUtils\SumasConceptos\SumasConceptos;
 use PHPUnit\Framework\TestCase;
 
-class SumasConceptosTest extends TestCase
+final class SumasConceptosTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/CfdiUtilsTests/SumasConceptos/SumasConceptosTest.php
+++ b/tests/CfdiUtilsTests/SumasConceptos/SumasConceptosTest.php
@@ -15,13 +15,13 @@ class SumasConceptosTest extends TestCase
         $maxDiff = 0.0000001;
         $sc = new SumasConceptos(new Node('x'));
         $this->assertSame(2, $sc->getPrecision());
-        $this->assertEquals(0, $sc->getSubTotal(), '', $maxDiff);
-        $this->assertEquals(0, $sc->getTotal(), '', $maxDiff);
-        $this->assertEquals(0, $sc->getDescuento(), '', $maxDiff);
-        $this->assertEquals(0, $sc->getImpuestosRetenidos(), '', $maxDiff);
-        $this->assertEquals(0, $sc->getImpuestosTrasladados(), '', $maxDiff);
-        $this->assertEquals(0, $sc->getLocalesImpuestosRetenidos(), '', $maxDiff);
-        $this->assertEquals(0, $sc->getLocalesImpuestosTrasladados(), '', $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getSubTotal(), $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getTotal(), $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getDescuento(), $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getImpuestosRetenidos(), $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getImpuestosTrasladados(), $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getLocalesImpuestosRetenidos(), $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getLocalesImpuestosTrasladados(), $maxDiff);
         $this->assertCount(0, $sc->getRetenciones());
         $this->assertCount(0, $sc->getTraslados());
         $this->assertCount(0, $sc->getLocalesRetenciones());
@@ -32,7 +32,7 @@ class SumasConceptosTest extends TestCase
         $this->assertFalse($sc->hasLocalesTraslados());
     }
 
-    public function providerWithConceptsDecimals()
+    public function providerWithConceptsDecimals(): array
     {
         /*
          * The case "tax uses 1 dec" 53.4 = round(35.6 + 17.8, 2)
@@ -51,7 +51,7 @@ class SumasConceptosTest extends TestCase
      * @param float $total
      * @dataProvider providerWithConceptsDecimals
      */
-    public function testWithConceptsDecimals($taxDecimals, $subtotal, $traslados, $total)
+    public function testWithConceptsDecimals(int $taxDecimals, float $subtotal, float $traslados, float $total)
     {
         $maxDiff = 0.0000001;
         $comprobante = new Comprobante();
@@ -72,12 +72,12 @@ class SumasConceptosTest extends TestCase
             'Importe' => number_format(222.22 * 0.16, $taxDecimals, '.', ''),
         ]);
         $sc = new SumasConceptos($comprobante, 2);
-        $this->assertEquals($subtotal, $sc->getSubTotal(), '', $maxDiff);
-        $this->assertEquals($traslados, $sc->getImpuestosTrasladados(), '', $maxDiff);
-        $this->assertEquals($total, $sc->getTotal(), '', $maxDiff);
+        $this->assertEqualsWithDelta($subtotal, $sc->getSubTotal(), $maxDiff);
+        $this->assertEqualsWithDelta($traslados, $sc->getImpuestosTrasladados(), $maxDiff);
+        $this->assertEqualsWithDelta($total, $sc->getTotal(), $maxDiff);
         // this are zero
-        $this->assertEquals(0, $sc->getDescuento(), '', $maxDiff);
-        $this->assertEquals(0, $sc->getImpuestosRetenidos(), '', $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getDescuento(), $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getImpuestosRetenidos(), $maxDiff);
         $this->assertCount(0, $sc->getRetenciones());
     }
 
@@ -115,15 +115,15 @@ class SumasConceptosTest extends TestCase
         $this->assertTrue($sc->hasTraslados());
         $this->assertCount(1, $sc->getLocalesTraslados());
 
-        $this->assertEquals(333.33, $sc->getSubTotal(), '', $maxDiff);
-        $this->assertEquals(53.33, $sc->getImpuestosTrasladados(), '', $maxDiff);
-        $this->assertEquals(8.33, $sc->getLocalesImpuestosTrasladados(), '', $maxDiff);
-        $this->assertEquals(333.33 + 53.33 + 8.33, $sc->getTotal(), '', $maxDiff);
+        $this->assertEqualsWithDelta(333.33, $sc->getSubTotal(), $maxDiff);
+        $this->assertEqualsWithDelta(53.33, $sc->getImpuestosTrasladados(), $maxDiff);
+        $this->assertEqualsWithDelta(8.33, $sc->getLocalesImpuestosTrasladados(), $maxDiff);
+        $this->assertEqualsWithDelta(333.33 + 53.33 + 8.33, $sc->getTotal(), $maxDiff);
         // this are zero
-        $this->assertEquals(0, $sc->getDescuento(), '', $maxDiff);
-        $this->assertEquals(0, $sc->getImpuestosRetenidos(), '', $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getDescuento(), $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getImpuestosRetenidos(), $maxDiff);
         $this->assertCount(0, $sc->getRetenciones());
-        $this->assertEquals(0, $sc->getLocalesImpuestosRetenidos(), '', $maxDiff);
+        $this->assertEqualsWithDelta(0, $sc->getLocalesImpuestosRetenidos(), $maxDiff);
         $this->assertCount(0, $sc->getLocalesRetenciones());
     }
 
@@ -152,8 +152,8 @@ class SumasConceptosTest extends TestCase
         $sumas = new SumasConceptos($comprobante, 3);
 
         $this->assertTrue($sumas->hasTraslados());
-        $this->assertEquals(10.0, $sumas->getImpuestosTrasladados(), '', 0.0001);
-        $this->assertEquals(10.0, $sumas->getTraslados()['002:Tasa:0.160000']['Importe'], '', 0.0000001);
+        $this->assertEqualsWithDelta(10.0, $sumas->getImpuestosTrasladados(), 0.0001);
+        $this->assertEqualsWithDelta(10.0, $sumas->getTraslados()['002:Tasa:0.160000']['Importe'], 0.0000001);
     }
 
     public function testImpuestoWithTrasladosTasaAndExento()
@@ -181,7 +181,7 @@ class SumasConceptosTest extends TestCase
 
         $sumas = new SumasConceptos($comprobante, 2);
         $this->assertTrue($sumas->hasTraslados());
-        $this->assertEquals(320.0, $sumas->getImpuestosTrasladados(), '', 0.001);
+        $this->assertEqualsWithDelta(320.0, $sumas->getImpuestosTrasladados(), 0.001);
         $this->assertCount(1, $sumas->getTraslados());
     }
 
@@ -197,7 +197,7 @@ class SumasConceptosTest extends TestCase
 
         $sumas = new SumasConceptos($comprobante, 2);
         $this->assertFalse($sumas->hasTraslados());
-        $this->assertEquals(0, $sumas->getImpuestosTrasladados(), '', 0.001);
+        $this->assertEqualsWithDelta(0, $sumas->getImpuestosTrasladados(), 0.001);
         $this->assertCount(0, $sumas->getTraslados());
     }
 }

--- a/tests/CfdiUtilsTests/TestCase.php
+++ b/tests/CfdiUtilsTests/TestCase.php
@@ -7,7 +7,7 @@ use CfdiUtils\XmlResolver\XmlResolver;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public static function utilAsset(string $file)
+    public static function utilAsset(string $file): string
     {
         return dirname(__DIR__) . '/assets/' . $file;
     }
@@ -17,8 +17,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return ('\\' === DIRECTORY_SEPARATOR);
     }
 
-    /** @return XmlResolver */
-    protected function newResolver()
+    protected function newResolver(): XmlResolver
     {
         return new XmlResolver();
     }

--- a/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdCadenaDeOrigenTest.php
+++ b/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdCadenaDeOrigenTest.php
@@ -29,7 +29,6 @@ class TfdCadenaDeOrigenTest extends TestCase
         $tfd = $cfdi->getNode()->searchNode('cfdi:Complemento', 'tfd:TimbreFiscalDigital');
         if (null === $tfd) {
             $this->fail('Cannot get the tfd:TimbreFiscalDigital node');
-            return;
         }
         $tfdXml = XmlNodeUtils::nodeToXmlString($tfd);
 

--- a/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdCadenaDeOrigenTest.php
+++ b/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdCadenaDeOrigenTest.php
@@ -50,8 +50,8 @@ class TfdCadenaDeOrigenTest extends TestCase
 
     public function testXsltLocation()
     {
-        $this->assertContains('TFD_1_0.xslt', TfdCadenaDeOrigen::xsltLocation('1.0'));
-        $this->assertContains('TFD_1_1.xslt', TfdCadenaDeOrigen::xsltLocation('1.1'));
+        $this->assertStringContainsString('TFD_1_0.xslt', TfdCadenaDeOrigen::xsltLocation('1.0'));
+        $this->assertStringContainsString('TFD_1_1.xslt', TfdCadenaDeOrigen::xsltLocation('1.1'));
     }
 
     public function testXsltLocationException()

--- a/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdCadenaDeOrigenTest.php
+++ b/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdCadenaDeOrigenTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\TimbreFiscalDigital\TfdCadenaDeOrigen;
 use CfdiUtils\XmlResolver\XmlResolver;
 use CfdiUtilsTests\TestCase;
 
-class TfdCadenaDeOrigenTest extends TestCase
+final class TfdCadenaDeOrigenTest extends TestCase
 {
     public function testConstructorMinimal()
     {

--- a/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdVersionTest.php
+++ b/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdVersionTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Nodes\XmlNodeUtils;
 use CfdiUtils\TimbreFiscalDigital\TfdVersion;
 use CfdiUtilsTests\TestCase;
 
-class TfdVersionTest extends TestCase
+final class TfdVersionTest extends TestCase
 {
     public function providerTfdVersion(): array
     {

--- a/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdVersionTest.php
+++ b/tests/CfdiUtilsTests/TimbreFiscalDigital/TfdVersionTest.php
@@ -9,7 +9,7 @@ use CfdiUtilsTests\TestCase;
 
 class TfdVersionTest extends TestCase
 {
-    public function providerTfdVersion()
+    public function providerTfdVersion(): array
     {
         return [
             '1.1' => ['1.1', 'Version', '1.1'],
@@ -31,7 +31,7 @@ class TfdVersionTest extends TestCase
      * @param string|null $value
      * @dataProvider providerTfdVersion
      */
-    public function testTfdVersion($expected, $attribute, $value)
+    public function testTfdVersion(string $expected, string $attribute, ?string $value)
     {
         $node = new Node('tfd', [$attribute => $value]);
         $tfdVersion = new TfdVersion();

--- a/tests/CfdiUtilsTests/UseCases/ReadCfdiWithTimbreOnSecondComplementoTest.php
+++ b/tests/CfdiUtilsTests/UseCases/ReadCfdiWithTimbreOnSecondComplementoTest.php
@@ -69,7 +69,7 @@ class ReadCfdiWithTimbreOnSecondComplementoTest extends TestCase
         );
     }
 
-    protected function createCfdiForTesting(string $uuid)
+    protected function createCfdiForTesting(string $uuid): string
     {
         $cerfile = $this->utilAsset('certs/CSD01_AAA010101AAA.cer');
         $keyfile = $this->utilAsset('certs/CSD01_AAA010101AAA.key.pem');

--- a/tests/CfdiUtilsTests/UseCases/ReadCfdiWithTimbreOnSecondComplementoTest.php
+++ b/tests/CfdiUtilsTests/UseCases/ReadCfdiWithTimbreOnSecondComplementoTest.php
@@ -14,7 +14,7 @@ use CfdiUtils\Nodes\Node;
 use CfdiUtils\Utils\Format;
 use CfdiUtilsTests\TestCase;
 
-class ReadCfdiWithTimbreOnSecondComplementoTest extends TestCase
+final class ReadCfdiWithTimbreOnSecondComplementoTest extends TestCase
 {
     public function testRetrieveTimbre()
     {

--- a/tests/CfdiUtilsTests/Utils/CurrencyDecimalsTest.php
+++ b/tests/CfdiUtilsTests/Utils/CurrencyDecimalsTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Utils;
 use CfdiUtils\Utils\CurrencyDecimals;
 use CfdiUtilsTests\TestCase;
 
-class CurrencyDecimalsTest extends TestCase
+final class CurrencyDecimalsTest extends TestCase
 {
     public function testCreateGeneric()
     {

--- a/tests/CfdiUtilsTests/Utils/RfcTest.php
+++ b/tests/CfdiUtilsTests/Utils/RfcTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Utils;
 use CfdiUtils\Utils\Rfc;
 use CfdiUtilsTests\TestCase;
 
-class RfcTest extends TestCase
+final class RfcTest extends TestCase
 {
     public function testCreateRfcPerson()
     {

--- a/tests/CfdiUtilsTests/Utils/SchemaLocationsTest.php
+++ b/tests/CfdiUtilsTests/Utils/SchemaLocationsTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Utils;
 use CfdiUtils\Utils\SchemaLocations;
 use CfdiUtilsTests\TestCase;
 
-class SchemaLocationsTest extends TestCase
+final class SchemaLocationsTest extends TestCase
 {
     public function testConstructorWithEmptyValue()
     {

--- a/tests/CfdiUtilsTests/Utils/XmlTest.php
+++ b/tests/CfdiUtilsTests/Utils/XmlTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Utils\Xml;
 use CfdiUtilsTests\TestCase;
 use DOMDocument;
 
-class XmlTest extends TestCase
+final class XmlTest extends TestCase
 {
     public function testMethodNewDocumentContentWithInvalidXmlEncoding()
     {

--- a/tests/CfdiUtilsTests/Validate/AssertTest.php
+++ b/tests/CfdiUtilsTests/Validate/AssertTest.php
@@ -72,8 +72,8 @@ class AssertTest extends TestCase
     {
         $assert = new Assert('CODE', 'Title', Status::ok());
         $value = (string) $assert;
-        $this->assertContains('CODE', $value);
-        $this->assertContains('Title', $value);
-        $this->assertContains(Status::STATUS_OK, $value);
+        $this->assertStringContainsString('CODE', $value);
+        $this->assertStringContainsString('Title', $value);
+        $this->assertStringContainsString(Status::STATUS_OK, $value);
     }
 }

--- a/tests/CfdiUtilsTests/Validate/AssertTest.php
+++ b/tests/CfdiUtilsTests/Validate/AssertTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Validate\Assert;
 use CfdiUtils\Validate\Status;
 use PHPUnit\Framework\TestCase;
 
-class AssertTest extends TestCase
+final class AssertTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/CfdiUtilsTests/Validate/AssertsTest.php
+++ b/tests/CfdiUtilsTests/Validate/AssertsTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Asserts;
 use CfdiUtils\Validate\Status;
 use PHPUnit\Framework\TestCase;
 
-class AssertsTest extends TestCase
+final class AssertsTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/CfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/CfdiRelacionadosTest.php
@@ -10,7 +10,7 @@ class CfdiRelacionadosTest extends ValidateComplementoPagosTestCase
     /** @var CfdiRelacionados */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new CfdiRelacionados();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/CfdiRelacionadosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/CfdiRelacionadosTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\Cfdi33\RecepcionPagos;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\CfdiRelacionados;
 use CfdiUtils\Validate\Status;
 
-class CfdiRelacionadosTest extends ValidateComplementoPagosTestCase
+final class CfdiRelacionadosTest extends ValidateComplementoPagosTestCase
 {
     /** @var CfdiRelacionados */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComplementoPagosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComplementoPagosTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\ComplementoPagos;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ComplementoPagosTest extends ValidateTestCase
+final class ComplementoPagosTest extends ValidateTestCase
 {
     /** @var ComplementoPagos */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComplementoPagosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComplementoPagosTest.php
@@ -13,7 +13,7 @@ class ComplementoPagosTest extends ValidateTestCase
     /** @var ComplementoPagos */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComplementoPagos();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComprobantePagosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComprobantePagosTest.php
@@ -11,7 +11,7 @@ class ComprobantePagosTest extends ValidateComplementoPagosTestCase
     /** @var ComprobantePagos */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComprobantePagos();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComprobantePagosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComprobantePagosTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Pagos10\Pagos;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\ComprobantePagos;
 use CfdiUtils\Validate\Status;
 
-class ComprobantePagosTest extends ValidateComplementoPagosTestCase
+final class ComprobantePagosTest extends ValidateComplementoPagosTestCase
 {
     /** @var ComprobantePagos */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComprobantePagosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ComprobantePagosTest.php
@@ -74,7 +74,7 @@ class ComprobantePagosTest extends ValidateComplementoPagosTestCase
      *           [null]
      *           ["MXN"]
      */
-    public function testErrorWithMonedaNotXxx($input)
+    public function testErrorWithMonedaNotXxx(?string $input)
     {
         $this->getComprobante()->addAttributes([
             'Moneda' => $input,
@@ -107,7 +107,7 @@ class ComprobantePagosTest extends ValidateComplementoPagosTestCase
      *           [null]
      *           ["0.0"]
      */
-    public function testErrorWithSubTotalNotZero($input)
+    public function testErrorWithSubTotalNotZero(?string $input)
     {
         $this->getComprobante()->addAttributes([
             'SubTotal' => $input,
@@ -122,7 +122,7 @@ class ComprobantePagosTest extends ValidateComplementoPagosTestCase
      *           [null]
      *           ["0.0"]
      */
-    public function testErrorWithTotalNotZero($input)
+    public function testErrorWithTotalNotZero(?string $input)
     {
         $this->getComprobante()->addAttributes([
             'Total' => $input,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ConceptosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ConceptosTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Nodes\Node;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Conceptos;
 use CfdiUtils\Validate\Status;
 
-class ConceptosTest extends ValidateComplementoPagosTestCase
+final class ConceptosTest extends ValidateComplementoPagosTestCase
 {
     /** @var Conceptos */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ConceptosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ConceptosTest.php
@@ -48,7 +48,7 @@ class ConceptosTest extends ValidateComplementoPagosTestCase
 
         $assert = $this->getAssertByCodeOrFail('PAGCON01');
         $this->assertStatusEqualsAssert(Status::error(), $assert);
-        $this->assertContains('No se encontró el nodo Conceptos', $assert->getExplanation());
+        $this->assertStringContainsString('No se encontró el nodo Conceptos', $assert->getExplanation());
     }
 
     public function testConceptosZeroChildren()
@@ -60,7 +60,7 @@ class ConceptosTest extends ValidateComplementoPagosTestCase
 
         $assert = $this->getAssertByCodeOrFail('PAGCON01');
         $this->assertStatusEqualsAssert(Status::error(), $assert);
-        $this->assertContains('Se esperaba encontrar un solo hijo de conceptos', $assert->getExplanation());
+        $this->assertStringContainsString('Se esperaba encontrar un solo hijo de conceptos', $assert->getExplanation());
     }
 
     public function testConceptosChildrenMoreThanOne()
@@ -72,7 +72,7 @@ class ConceptosTest extends ValidateComplementoPagosTestCase
 
         $assert = $this->getAssertByCodeOrFail('PAGCON01');
         $this->assertStatusEqualsAssert(Status::error(), $assert);
-        $this->assertContains('Se esperaba encontrar un solo hijo de conceptos', $assert->getExplanation());
+        $this->assertStringContainsString('Se esperaba encontrar un solo hijo de conceptos', $assert->getExplanation());
     }
 
     public function testConceptosChildIsNotConcepto()
@@ -86,7 +86,7 @@ class ConceptosTest extends ValidateComplementoPagosTestCase
 
         $assert = $this->getAssertByCodeOrFail('PAGCON01');
         $this->assertStatusEqualsAssert(Status::error(), $assert);
-        $this->assertContains('No se encontró el nodo Concepto', $assert->getExplanation());
+        $this->assertStringContainsString('No se encontró el nodo Concepto', $assert->getExplanation());
     }
 
     public function testConceptoWithChildren()
@@ -97,10 +97,10 @@ class ConceptosTest extends ValidateComplementoPagosTestCase
 
         $assert = $this->getAssertByCodeOrFail('PAGCON01');
         $this->assertStatusEqualsAssert(Status::error(), $assert);
-        $this->assertContains('Se esperaba encontrar ningún hijo de concepto', $assert->getExplanation());
+        $this->assertStringContainsString('Se esperaba encontrar ningún hijo de concepto', $assert->getExplanation());
     }
 
-    public function providerConceptoInvalidData()
+    public function providerConceptoInvalidData(): array
     {
         $second = [
             [null],
@@ -122,7 +122,7 @@ class ConceptosTest extends ValidateComplementoPagosTestCase
      * @param string|null $value
      * @dataProvider providerConceptoInvalidData
      */
-    public function testConceptoInvalidData(string $attribute, $value)
+    public function testConceptoInvalidData(string $attribute, ?string $value)
     {
         $this->concepto[$attribute] = $value;
 
@@ -131,7 +131,7 @@ class ConceptosTest extends ValidateComplementoPagosTestCase
         $this->assertStatusEqualsCode(Status::error(), 'PAGCON01');
     }
 
-    public function providerConceptoInvalidDataMustNotExists()
+    public function providerConceptoInvalidDataMustNotExists(): array
     {
         return [
             ['NoIdentificacion'],

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ConceptosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ConceptosTest.php
@@ -15,7 +15,7 @@ class ConceptosTest extends ValidateComplementoPagosTestCase
     /** @var Concepto */
     protected $concepto;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new Conceptos();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/CalculateDocumentAmountTraitTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/CalculateDocumentAmountTraitTest.php
@@ -15,7 +15,7 @@ class CalculateDocumentAmountTraitTest extends TestCase
             'ImpPagado' => '123.45',
         ]), new Pago());
 
-        $this->assertEquals(123.45, $amount, '', 0.001);
+        $this->assertEqualsWithDelta(123.45, $amount, 0.001);
     }
 
     public function testCalculateDocumentAmountWhenIsUndefined()
@@ -26,7 +26,7 @@ class CalculateDocumentAmountTraitTest extends TestCase
         $validator = new CalculateDocumentAmountUse();
         $amount = $validator->calculateDocumentAmount($docto, $pago);
 
-        $this->assertEquals(123.45, $amount, '', 0.001);
+        $this->assertEqualsWithDelta(123.45, $amount, 0.001);
     }
 
     public function testCalculateDocumentAmountWhenIsUndefinedWithExchangeRate()
@@ -37,7 +37,7 @@ class CalculateDocumentAmountTraitTest extends TestCase
         $validator = new CalculateDocumentAmountUse();
         $amount = $validator->calculateDocumentAmount($docto, $pago);
 
-        $this->assertEquals(0, $amount, '', 0.001);
+        $this->assertEqualsWithDelta(0, $amount, 0.001);
     }
 
     public function testCalculateDocumentAmountWhenIsUndefinedWithMoreDocuments()
@@ -49,6 +49,6 @@ class CalculateDocumentAmountTraitTest extends TestCase
         $validator = new CalculateDocumentAmountUse();
         $amount = $validator->calculateDocumentAmount($docto, $pago);
 
-        $this->assertEquals(0, $amount, '', 0.001);
+        $this->assertEqualsWithDelta(0, $amount, 0.001);
     }
 }

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/CalculateDocumentAmountTraitTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/CalculateDocumentAmountTraitTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Elements\Pagos10\DoctoRelacionado;
 use CfdiUtils\Elements\Pagos10\Pago;
 use PHPUnit\Framework\TestCase;
 
-class CalculateDocumentAmountTraitTest extends TestCase
+final class CalculateDocumentAmountTraitTest extends TestCase
 {
     public function testCalculateDocumentAmountWhenIsSet()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/CalculateDocumentAmountUse.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/CalculateDocumentAmountUse.php
@@ -4,7 +4,7 @@ namespace CfdiUtilsTests\Validate\Cfdi33\RecepcionPagos\Helpers;
 
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Helpers\CalculateDocumentAmountTrait;
 
-class CalculateDocumentAmountUse
+final class CalculateDocumentAmountUse
 {
     use CalculateDocumentAmountTrait;
 }

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/FormaPagoCatalogTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/FormaPagoCatalogTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\Cfdi33\RecepcionPagos\Helpers;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Helpers\FormaPagoCatalog;
 use PHPUnit\Framework\TestCase;
 
-class FormaPagoCatalogTest extends TestCase
+final class FormaPagoCatalogTest extends TestCase
 {
     public function providerObtain(): array
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/FormaPagoCatalogTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/FormaPagoCatalogTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class FormaPagoCatalogTest extends TestCase
 {
-    public function providerObtain()
+    public function providerObtain(): array
     {
         return [
             'Efectivo' => ['01'],

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/FormaPagoEntryTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Helpers/FormaPagoEntryTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\Cfdi33\RecepcionPagos\Helpers;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Helpers\FormaPagoEntry;
 use PHPUnit\Framework\TestCase;
 
-class FormaPagoEntryTest extends TestCase
+final class FormaPagoEntryTest extends TestCase
 {
     /**
      * @param string $key

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/PagoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/PagoTest.php
@@ -9,7 +9,7 @@ class PagoTest extends ValidateComplementoPagosTestCase
     /** @var Pago */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new Pago();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/PagoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/PagoTest.php
@@ -4,7 +4,7 @@ namespace CfdiUtilsTests\Validate\Cfdi33\RecepcionPagos;
 
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago;
 
-class PagoTest extends ValidateComplementoPagosTestCase
+final class PagoTest extends ValidateComplementoPagosTestCase
 {
     /** @var Pago */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcCorrectoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcCorrectoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\BancoBeneficiarioRfcCorrecto;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class BancoBeneficiarioRfcCorrectoTest extends TestCase
+final class BancoBeneficiarioRfcCorrectoTest extends TestCase
 {
     /**
      * @param string|null $rfc

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcCorrectoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcCorrectoTest.php
@@ -15,7 +15,7 @@ class BancoBeneficiarioRfcCorrectoTest extends TestCase
      *           ["XEXX010101000"]
      *           [null]
      */
-    public function testValid($rfc)
+    public function testValid(?string $rfc)
     {
         $pago = new Pago([
             'RfcEmisorCtaBen' => $rfc,
@@ -31,7 +31,7 @@ class BancoBeneficiarioRfcCorrectoTest extends TestCase
      *           ["XAXX010101000"]
      *           [""]
      */
-    public function testInvalid($rfc)
+    public function testInvalid(?string $rfc)
     {
         $pago = new Pago([
             'RfcEmisorCtaBen' => $rfc,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcProhibidoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcProhibidoTest.php
@@ -17,7 +17,7 @@ class BancoBeneficiarioRfcProhibidoTest extends TestCase
      *           ["02", null]
      *           ["01", null]
      */
-    public function testValid($paymentType, $rfc)
+    public function testValid(string $paymentType, ?string $rfc)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentType,
@@ -29,12 +29,12 @@ class BancoBeneficiarioRfcProhibidoTest extends TestCase
     }
 
     /**
-     * @param string|null $paymentType
-     * @param string|null $rfc
+     * @param string $paymentType
+     * @param string $rfc
      * @testWith ["01", "COSC8001137NA"]
      *           ["01", ""]
      */
-    public function testInvalid($paymentType, $rfc)
+    public function testInvalid(string $paymentType, string $rfc)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentType,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcProhibidoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcProhibidoTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class BancoBeneficiarioRfcProhibidoTest extends TestCase
 {
     /**
-     * @param string|null $paymentType
+     * @param string $paymentType
      * @param string|null $rfc
      * @testWith ["02", "COSC8001137NA"]
      *           ["02", ""]

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcProhibidoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoBeneficiarioRfcProhibidoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\BancoBeneficiarioRfcProhibido
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class BancoBeneficiarioRfcProhibidoTest extends TestCase
+final class BancoBeneficiarioRfcProhibidoTest extends TestCase
 {
     /**
      * @param string $paymentType

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteNombreRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteNombreRequeridoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\BancoOrdenanteNombreRequerido
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class BancoOrdenanteNombreRequeridoTest extends TestCase
+final class BancoOrdenanteNombreRequeridoTest extends TestCase
 {
     /**
      * @param string|null $rfc

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteNombreRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteNombreRequeridoTest.php
@@ -18,7 +18,7 @@ class BancoOrdenanteNombreRequeridoTest extends TestCase
      *           [null, "Foreign bank"]
      *           [null, null]
      */
-    public function testValid($rfc, $name)
+    public function testValid(?string $rfc, ?string $name)
     {
         $pago = new Pago([
             'RfcEmisorCtaOrd' => $rfc,
@@ -30,12 +30,12 @@ class BancoOrdenanteNombreRequeridoTest extends TestCase
     }
 
     /**
-     * @param string|null $rfc
+     * @param string $rfc
      * @param string|null $name
      * @testWith ["XEXX010101000", ""]
      *           ["XEXX010101000", null]
      */
-    public function testInvalid($rfc, $name)
+    public function testInvalid(string $rfc, ?string $name)
     {
         $pago = new Pago([
             'RfcEmisorCtaOrd' => $rfc,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteRfcCorrectoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteRfcCorrectoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\BancoOrdenanteRfcCorrecto;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class BancoOrdenanteRfcCorrectoTest extends TestCase
+final class BancoOrdenanteRfcCorrectoTest extends TestCase
 {
     /**
      * @param string|null $rfc

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteRfcCorrectoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteRfcCorrectoTest.php
@@ -15,7 +15,7 @@ class BancoOrdenanteRfcCorrectoTest extends TestCase
      *           ["XEXX010101000"]
      *           [null]
      */
-    public function testValid($rfc)
+    public function testValid(?string $rfc)
     {
         $pago = new Pago([
             'RfcEmisorCtaOrd' => $rfc,
@@ -26,12 +26,12 @@ class BancoOrdenanteRfcCorrectoTest extends TestCase
     }
 
     /**
-     * @param string|null $rfc
+     * @param string $rfc
      * @testWith ["COSC8099137N1"]
      *           ["XAXX010101000"]
      *           [""]
      */
-    public function testInvalid($rfc)
+    public function testInvalid(string $rfc)
     {
         $pago = new Pago([
             'RfcEmisorCtaOrd' => $rfc,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteRfcProhibidoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteRfcProhibidoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\BancoOrdenanteRfcProhibido;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class BancoOrdenanteRfcProhibidoTest extends TestCase
+final class BancoOrdenanteRfcProhibidoTest extends TestCase
 {
     /**
      * @param string $paymentType

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteRfcProhibidoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/BancoOrdenanteRfcProhibidoTest.php
@@ -10,14 +10,14 @@ use PHPUnit\Framework\TestCase;
 class BancoOrdenanteRfcProhibidoTest extends TestCase
 {
     /**
-     * @param string|null $paymentType
+     * @param string $paymentType
      * @param string|null $rfc
      * @testWith ["02", "COSC8001137NA"]
      *           ["02", ""]
      *           ["02", null]
      *           ["01", null]
      */
-    public function testValid($paymentType, $rfc)
+    public function testValid(string $paymentType, ?string $rfc)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentType,
@@ -30,12 +30,12 @@ class BancoOrdenanteRfcProhibidoTest extends TestCase
 
     /**
      * @param string|null $paymentType
-     * @param string|null $rfc
+     * @param string $rfc
      * @testWith ["01", "COSC8001137NA"]
      *           ["01", ""]
      *           [null, "COSC8001137NA"]
      */
-    public function testInvalid($paymentType, $rfc)
+    public function testInvalid(?string $paymentType, string $rfc)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentType,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaBeneficiariaPatronTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaBeneficiariaPatronTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\CuentaBeneficiariaPatron;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class CuentaBeneficiariaPatronTest extends TestCase
+final class CuentaBeneficiariaPatronTest extends TestCase
 {
     /**
      * @param string|null $input

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaBeneficiariaPatronTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaBeneficiariaPatronTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
 class CuentaBeneficiariaPatronTest extends TestCase
 {
     /**
-     * @param string $input
+     * @param string|null $input
      * @testWith ["1234567890123456"]
      *           [null]
      */
-    public function testValid($input)
+    public function testValid(?string $input)
     {
         $pago = new Pago([
             'FormaDePagoP' => '04', // require a pattern of 16 digits
@@ -29,7 +29,7 @@ class CuentaBeneficiariaPatronTest extends TestCase
      * @testWith ["1"]
      *           [""]
      */
-    public function testInvalid($input)
+    public function testInvalid(string $input)
     {
         $pago = new Pago([
             'FormaDePagoP' => '04', // require a pattern of 16 digits

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaBeneficiariaProhibidaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaBeneficiariaProhibidaTest.php
@@ -10,14 +10,14 @@ use PHPUnit\Framework\TestCase;
 class CuentaBeneficiariaProhibidaTest extends TestCase
 {
     /**
-     * @param string|null $paymentType
+     * @param string $paymentType
      * @param string|null $account
      * @testWith ["02", "x"]
      *           ["02", ""]
      *           ["02", null]
      *           ["01", null]
      */
-    public function testValid($paymentType, $account)
+    public function testValid(string $paymentType, ?string $account)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentType,
@@ -29,12 +29,12 @@ class CuentaBeneficiariaProhibidaTest extends TestCase
     }
 
     /**
-     * @param string|null $paymentType
-     * @param string|null $account
+     * @param string $paymentType
+     * @param string $account
      * @testWith ["01", "x"]
      *           ["01", ""]
      */
-    public function testInvalid($paymentType, $account)
+    public function testInvalid(string $paymentType, string $account)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentType,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaBeneficiariaProhibidaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaBeneficiariaProhibidaTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\CuentaBeneficiariaProhibida;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class CuentaBeneficiariaProhibidaTest extends TestCase
+final class CuentaBeneficiariaProhibidaTest extends TestCase
 {
     /**
      * @param string $paymentType

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaOrdenantePatronTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaOrdenantePatronTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
 class CuentaOrdenantePatronTest extends TestCase
 {
     /**
-     * @param string $input
+     * @param string|null $input
      * @testWith ["1234567890123456"]
      *           [null]
      */
-    public function testValid($input)
+    public function testValid(?string $input)
     {
         $pago = new Pago([
             'FormaDePagoP' => '04', // require a pattern of 16 digits
@@ -29,7 +29,7 @@ class CuentaOrdenantePatronTest extends TestCase
      * @testWith ["1"]
      *           [""]
      */
-    public function testInvalid($input)
+    public function testInvalid(string $input)
     {
         $pago = new Pago([
             'FormaDePagoP' => '04', // require a pattern of 16 digits

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaOrdenantePatronTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaOrdenantePatronTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\CuentaOrdenantePatron;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class CuentaOrdenantePatronTest extends TestCase
+final class CuentaOrdenantePatronTest extends TestCase
 {
     /**
      * @param string|null $input

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaOrdenanteProhibidaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaOrdenanteProhibidaTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\CuentaOrdenanteProhibida;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class CuentaOrdenanteProhibidaTest extends TestCase
+final class CuentaOrdenanteProhibidaTest extends TestCase
 {
     /**
      * @param string $paymentType

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaOrdenanteProhibidaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/CuentaOrdenanteProhibidaTest.php
@@ -10,14 +10,14 @@ use PHPUnit\Framework\TestCase;
 class CuentaOrdenanteProhibidaTest extends TestCase
 {
     /**
-     * @param string|null $paymentType
+     * @param string $paymentType
      * @param string|null $account
      * @testWith ["02", "x"]
      *           ["02", ""]
      *           ["02", null]
      *           ["01", null]
      */
-    public function testValid($paymentType, $account)
+    public function testValid(string $paymentType, ?string $account)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentType,
@@ -29,12 +29,12 @@ class CuentaOrdenanteProhibidaTest extends TestCase
     }
 
     /**
-     * @param string|null $paymentType
-     * @param string|null $account
+     * @param string $paymentType
+     * @param string $account
      * @testWith ["01", "x"]
      *           ["01", ""]
      */
-    public function testInvalid($paymentType, $account)
+    public function testInvalid(string $paymentType, string $account)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentType,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportePagadoRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportePagadoRequeridoTest.php
@@ -22,11 +22,11 @@ class ImportePagadoRequeridoTest extends TestCase
     }
 
     /**
-     * @param string|null $exchangeRate
+     * @param string $exchangeRate
      * @testWith ["19.8765"]
      *           [""]
      */
-    public function testInvalidExchangeRate($exchangeRate)
+    public function testInvalidExchangeRate(string $exchangeRate)
     {
         $pago = new Pago();
         $docto = $pago->addDoctoRelacionado([

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportePagadoRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportePagadoRequeridoTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ImportePagad
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class ImportePagadoRequeridoTest extends TestCase
+final class ImportePagadoRequeridoTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportePagadoValorTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportePagadoValorTest.php
@@ -11,11 +11,11 @@ use PHPUnit\Framework\TestCase;
 class ImportePagadoValorTest extends TestCase
 {
     /**
-     * @param string|null $input
+     * @param string $input
      * @testWith ["0.01"]
      *           ["123456.78"]
      */
-    public function testValid($input)
+    public function testValid(string $input)
     {
         $docto = new DoctoRelacionado([
             'ImpPagado' => $input,
@@ -44,7 +44,7 @@ class ImportePagadoValorTest extends TestCase
      *           [""]
      *           [null]
      */
-    public function testInvalid($input)
+    public function testInvalid(?string $input)
     {
         $pago = new Pago();
         $docto = $pago->addDoctoRelacionado([

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportePagadoValorTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportePagadoValorTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ImportePagad
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class ImportePagadoValorTest extends TestCase
+final class ImportePagadoValorTest extends TestCase
 {
     /**
      * @param string $input

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoAnteriorRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoAnteriorRequeridoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ImporteSaldo
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class ImporteSaldoAnteriorRequeridoTest extends TestCase
+final class ImporteSaldoAnteriorRequeridoTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoAnteriorValorTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoAnteriorValorTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
 class ImporteSaldoAnteriorValorTest extends TestCase
 {
     /**
-     * @param string|null $input
+     * @param string $input
      * @testWith ["0.01"]
      *           ["123456.78"]
      */
-    public function testValid($input)
+    public function testValid(string $input)
     {
         $docto = new DoctoRelacionado([
             'ImpSaldoAnt' => $input,
@@ -32,7 +32,7 @@ class ImporteSaldoAnteriorValorTest extends TestCase
      *           [""]
      *           [null]
      */
-    public function testInvalid($input)
+    public function testInvalid(?string $input)
     {
         $docto = new DoctoRelacionado([
             'ImpSaldoAnt' => $input,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoAnteriorValorTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoAnteriorValorTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ImporteSaldo
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class ImporteSaldoAnteriorValorTest extends TestCase
+final class ImporteSaldoAnteriorValorTest extends TestCase
 {
     /**
      * @param string $input

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoInsolutoRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoInsolutoRequeridoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ImporteSaldo
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class ImporteSaldoInsolutoRequeridoTest extends TestCase
+final class ImporteSaldoInsolutoRequeridoTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoInsolutoValorTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoInsolutoValorTest.php
@@ -15,7 +15,7 @@ class ImporteSaldoInsolutoValorTest extends TestCase
      * @param string $left
      * @testWith ["100.00", "100.00", "0.0"]
      */
-    public function testValid($previous, $payment, $left)
+    public function testValid(string $previous, string $payment, string $left)
     {
         $pago = new Pago();
         $docto = $pago->addDoctoRelacionado([
@@ -36,7 +36,7 @@ class ImporteSaldoInsolutoValorTest extends TestCase
      * @param string $left
      * @testWith ["150.00", "100.00", "50.0"]
      */
-    public function testWithCalculate($previous, $payment, $left)
+    public function testWithCalculate(string $previous, string $payment, string $left)
     {
         $pago = new Pago(['Monto' => $payment]);
         $docto = $pago->addDoctoRelacionado([
@@ -59,7 +59,7 @@ class ImporteSaldoInsolutoValorTest extends TestCase
      *           ["100.01", "100.00", "0.00"]
      *           ["100.00", "100.01", "0.00"]
      */
-    public function testInvalid($previous, $payment, $left)
+    public function testInvalid(string $previous, string $payment, string $left)
     {
         $pago = new Pago();
         $docto = $pago->addDoctoRelacionado([

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoInsolutoValorTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImporteSaldoInsolutoValorTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ImporteSaldo
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class ImporteSaldoInsolutoValorTest extends TestCase
+final class ImporteSaldoInsolutoValorTest extends TestCase
 {
     /**
      * @param string $previous

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportesDecimalesTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportesDecimalesTest.php
@@ -18,7 +18,7 @@ class ImportesDecimalesTest extends TestCase
      *           ["MXN", "100.0", "100.0", "0.0"]
      *           ["MXN", "100", "100", "0"]
      */
-    public function testValid($currency, $previous, $payment, $left)
+    public function testValid(string $currency, string $previous, string $payment, string $left)
     {
         $pago = new Pago();
         $docto = $pago->addDoctoRelacionado([
@@ -43,7 +43,7 @@ class ImportesDecimalesTest extends TestCase
      *           ["MXN", "100.00", "100.000", "0.00"]
      *           ["MXN", "100.00", "100.00", "0.000"]
      */
-    public function testInvalid($currency, $previous, $payment, $left)
+    public function testInvalid(string $currency, string $previous, string $payment, string $left)
     {
         $pago = new Pago();
         $docto = $pago->addDoctoRelacionado([

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportesDecimalesTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/ImportesDecimalesTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ImportesDeci
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class ImportesDecimalesTest extends TestCase
+final class ImportesDecimalesTest extends TestCase
 {
     /**
      * @param string $currency

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/MonedaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/MonedaTest.php
@@ -16,7 +16,7 @@ class MonedaTest extends TestCase
      *           [""]
      *           [null]
      */
-    public function testValid($input)
+    public function testValid(?string $input)
     {
         $docto = new DoctoRelacionado([
             'MonedaDR' => $input,
@@ -28,10 +28,10 @@ class MonedaTest extends TestCase
     }
 
     /**
-     * @param string|null $input
+     * @param string $input
      * @testWith ["XXX"]
      */
-    public function testInvalid($input)
+    public function testInvalid(string $input)
     {
         $docto = new DoctoRelacionado([
             'MonedaDR' => $input,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/MonedaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/MonedaTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\Moneda;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class MonedaTest extends TestCase
+final class MonedaTest extends TestCase
 {
     /**
      * @param string|null $input

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/NumeroParcialidadRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/NumeroParcialidadRequeridoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\NumeroParcia
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class NumeroParcialidadRequeridoTest extends TestCase
+final class NumeroParcialidadRequeridoTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioRequeridoTest.php
@@ -16,7 +16,7 @@ class TipoCambioRequeridoTest extends TestCase
      * @testWith ["USD", "USD", null]
      *           ["MXN", "USD", "19.9876"]
      */
-    public function testValid($currencyPayment, $currencyDocument, $exchangeRate)
+    public function testValid(string $currencyPayment, string $currencyDocument, ?string $exchangeRate)
     {
         $pago = new Pago([
             'MonedaP' => $currencyPayment,
@@ -39,7 +39,7 @@ class TipoCambioRequeridoTest extends TestCase
      * @testWith ["USD", "USD", "19.9876"]
      *           ["MXN", "USD", null]
      */
-    public function testInvalid($currencyPayment, $currencyDocument, $exchangeRate)
+    public function testInvalid(string $currencyPayment, string $currencyDocument, ?string $exchangeRate)
     {
         $pago = new Pago([
             'MonedaP' => $currencyPayment,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioRequeridoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioRequeridoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\TipoCambioRe
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class TipoCambioRequeridoTest extends TestCase
+final class TipoCambioRequeridoTest extends TestCase
 {
     /**
      * @param string $currencyPayment

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioValorTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioValorTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\TipoCambioVa
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado\ValidateDoctoException;
 use PHPUnit\Framework\TestCase;
 
-class TipoCambioValorTest extends TestCase
+final class TipoCambioValorTest extends TestCase
 {
     /**
      * @param string $currencyPayment

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioValorTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioValorTest.php
@@ -12,10 +12,10 @@ class TipoCambioValorTest extends TestCase
     /**
      * @param string $currencyPayment
      * @param string $currencyDocument
-     * @param string|null $exchangeRate
+     * @param string $exchangeRate
      * @testWith ["USD", "MXN", "1"]
      */
-    public function testValid($currencyPayment, $currencyDocument, $exchangeRate)
+    public function testValid(string $currencyPayment, string $currencyDocument, string $exchangeRate)
     {
         $pago = new Pago([
             'MonedaP' => $currencyPayment,
@@ -39,7 +39,7 @@ class TipoCambioValorTest extends TestCase
      *           ["USD", "MXN", ""]
      *           ["USD", "MXN", null]
      */
-    public function testInvalid($currencyPayment, $currencyDocument, $exchangeRate)
+    public function testInvalid(string $currencyPayment, string $currencyDocument, ?string $exchangeRate)
     {
         $pago = new Pago([
             'MonedaP' => $currencyPayment,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionadoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionadoTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\Cfdi33\RecepcionPagos\Pagos;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\DoctoRelacionado;
 use PHPUnit\Framework\TestCase;
 
-class DoctoRelacionadoTest extends TestCase
+final class DoctoRelacionadoTest extends TestCase
 {
     public function testValidatorsCodes()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/FechaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/FechaTest.php
@@ -28,7 +28,7 @@ class FechaTest extends ValidateTestCase
      *           ["not a date"]
      *           ["2018-01-01"]
      */
-    public function testInvalid($fechaPago)
+    public function testInvalid(?string $fechaPago)
     {
         $pagoNode = new Pago([
             'FechaPago' => $fechaPago,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/FechaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/FechaTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\Fecha;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class FechaTest extends ValidateTestCase
+final class FechaTest extends ValidateTestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/FormaDePagoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/FormaDePagoTest.php
@@ -25,7 +25,7 @@ class FormaDePagoTest extends TestCase
      *           [""]
      *           ["99"]
      */
-    public function testInvalid($formaPago)
+    public function testInvalid(?string $formaPago)
     {
         $pago = new Pago([
             'FormaDePagoP' => $formaPago,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/FormaDePagoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/FormaDePagoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\FormaDePago;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class FormaDePagoTest extends TestCase
+final class FormaDePagoTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MonedaPagoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MonedaPagoTest.php
@@ -24,7 +24,7 @@ class MonedaPagoTest extends TestCase
      *           [""]
      *           ["XXX"]
      */
-    public function testInvalid($currency)
+    public function testInvalid(?string $currency)
     {
         $pago = new Pago([
             'MonedaP' => $currency,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MonedaPagoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MonedaPagoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\MonedaPago;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class MonedaPagoTest extends TestCase
+final class MonedaPagoTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoBetweenIntervalSumOfDocumentsTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoBetweenIntervalSumOfDocumentsTest.php
@@ -88,7 +88,7 @@ class MontoBetweenIntervalSumOfDocumentsTest extends TestCase
     {
         $randomValues = [];
         for ($i = 0; $i < 20; $i++) {
-            $randomValues[] = [rand(1, 99999999) / 100];
+            $randomValues[] = [random_int(1, 99999999) / 100];
         }
         return $randomValues;
     }

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoBetweenIntervalSumOfDocumentsTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoBetweenIntervalSumOfDocumentsTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\MontoBetweenIntervalSumOfDocu
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class MontoBetweenIntervalSumOfDocumentsTest extends TestCase
+final class MontoBetweenIntervalSumOfDocumentsTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoDecimalsTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoDecimalsTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\MontoDecimals;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class MontoDecimalsTest extends TestCase
+final class MontoDecimalsTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoDecimalsTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoDecimalsTest.php
@@ -21,12 +21,12 @@ class MontoDecimalsTest extends TestCase
     }
 
     /**
-     * @param string|null $amount
+     * @param string $amount
      * @testWith ["0.001"]
      *           ["0.000"]
      *           ["0.123"]
      */
-    public function testInvalid($amount)
+    public function testInvalid(string $amount)
     {
         $pago = new Pago([
             'MonedaP' => 'USD', // 2 decimals

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoGreaterOrEqualThanSumOfDocumentsTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoGreaterOrEqualThanSumOfDocumentsTest.php
@@ -52,7 +52,7 @@ class MontoGreaterOrEqualThanSumOfDocumentsTest extends TestCase
             'ImpPagado' => '123.45',
         ]), new Pago());
 
-        $this->assertEquals(123.45, $amount, '', 0.001);
+        $this->assertEqualsWithDelta(123.45, $amount, 0.001);
     }
 
     public function testCalculateDocumentAmountWhenIsUndefined()
@@ -63,7 +63,7 @@ class MontoGreaterOrEqualThanSumOfDocumentsTest extends TestCase
         $validator = new MontoGreaterOrEqualThanSumOfDocuments();
         $amount = $validator->calculateDocumentAmount($docto, $pago);
 
-        $this->assertEquals(123.45, $amount, '', 0.001);
+        $this->assertEqualsWithDelta(123.45, $amount, 0.001);
     }
 
     public function testCalculateDocumentAmountWhenIsUndefinedWithExchangeRate()
@@ -74,7 +74,7 @@ class MontoGreaterOrEqualThanSumOfDocumentsTest extends TestCase
         $validator = new MontoGreaterOrEqualThanSumOfDocuments();
         $amount = $validator->calculateDocumentAmount($docto, $pago);
 
-        $this->assertEquals(0, $amount, '', 0.001);
+        $this->assertEqualsWithDelta(0, $amount, 0.001);
     }
 
     public function testCalculateDocumentAmountWhenIsUndefinedWithMoreDocuments()
@@ -86,6 +86,6 @@ class MontoGreaterOrEqualThanSumOfDocumentsTest extends TestCase
         $validator = new MontoGreaterOrEqualThanSumOfDocuments();
         $amount = $validator->calculateDocumentAmount($docto, $pago);
 
-        $this->assertEquals(0, $amount, '', 0.001);
+        $this->assertEqualsWithDelta(0, $amount, 0.001);
     }
 }

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoGreaterOrEqualThanSumOfDocumentsTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoGreaterOrEqualThanSumOfDocumentsTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\MontoGreaterOrEqualThanSumOfD
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class MontoGreaterOrEqualThanSumOfDocumentsTest extends TestCase
+final class MontoGreaterOrEqualThanSumOfDocumentsTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoGreaterThanZeroTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoGreaterThanZeroTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\MontoGreaterThanZero;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class MontoGreaterThanZeroTest extends TestCase
+final class MontoGreaterThanZeroTest extends TestCase
 {
     /**
      * @param string $amount

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoGreaterThanZeroTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/MontoGreaterThanZeroTest.php
@@ -14,7 +14,7 @@ class MontoGreaterThanZeroTest extends TestCase
      * @testWith ["0.000001"]
      *           ["1"]
      */
-    public function testValid($amount)
+    public function testValid(string $amount)
     {
         $pago = new Pago([
             'Monto' => $amount,
@@ -32,7 +32,7 @@ class MontoGreaterThanZeroTest extends TestCase
      *           [""]
      *           ["not numeric"]
      */
-    public function testPagoMontoGreaterThanZeroInvalid($amount)
+    public function testPagoMontoGreaterThanZeroInvalid(?string $amount)
     {
         $pago = new Pago([
             'Monto' => $amount,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCadenaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCadenaTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\TipoCadenaPagoCadena;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class TipoCadenaPagoCadenaTest extends TestCase
+final class TipoCadenaPagoCadenaTest extends TestCase
 {
     /**
      * @param string|null $tipoCadPago

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCadenaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCadenaTest.php
@@ -15,7 +15,7 @@ class TipoCadenaPagoCadenaTest extends TestCase
      * @testWith [null, null]
      *           ["1", "1"]
      */
-    public function testValid($tipoCadPago, $input)
+    public function testValid(?string $tipoCadPago, ?string $input)
     {
         $pago = new Pago([
             'TipoCadPago' => $tipoCadPago,
@@ -36,7 +36,7 @@ class TipoCadenaPagoCadenaTest extends TestCase
      *           [null, ""]
      *           ["", null]
      */
-    public function testInvalid($tipoCadPago, $input)
+    public function testInvalid(?string $tipoCadPago, ?string $input)
     {
         $pago = new Pago([
             'TipoCadPago' => $tipoCadPago,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCertificadoTest.php
@@ -15,7 +15,7 @@ class TipoCadenaPagoCertificadoTest extends TestCase
      * @testWith [null, null]
      *           ["1", "1"]
      */
-    public function testValid($tipoCadPago, $input)
+    public function testValid(?string $tipoCadPago, ?string $input)
     {
         $pago = new Pago([
             'TipoCadPago' => $tipoCadPago,
@@ -36,7 +36,7 @@ class TipoCadenaPagoCertificadoTest extends TestCase
      *           [null, ""]
      *           ["", null]
      */
-    public function testInvalid($tipoCadPago, $input)
+    public function testInvalid(?string $tipoCadPago, ?string $input)
     {
         $pago = new Pago([
             'TipoCadPago' => $tipoCadPago,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCertificadoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\TipoCadenaPagoCertificado;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class TipoCadenaPagoCertificadoTest extends TestCase
+final class TipoCadenaPagoCertificadoTest extends TestCase
 {
     /**
      * @param string|null $tipoCadPago

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoProhibidoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoProhibidoTest.php
@@ -16,7 +16,7 @@ class TipoCadenaPagoProhibidoTest extends TestCase
      *           ["03", null]
      *           ["03", "SPEI"]
      */
-    public function testValid(string $paymentForm, $input)
+    public function testValid(string $paymentForm, ?string $input)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentForm,
@@ -33,7 +33,7 @@ class TipoCadenaPagoProhibidoTest extends TestCase
      * @testWith ["01", "SPEI"]
      *           ["01", ""]
      */
-    public function testInvalid(string $paymentForm, $input)
+    public function testInvalid(string $paymentForm, ?string $input)
     {
         $pago = new Pago([
             'FormaDePagoP' => $paymentForm,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoProhibidoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoProhibidoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\TipoCadenaPagoProhibido;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class TipoCadenaPagoProhibidoTest extends TestCase
+final class TipoCadenaPagoProhibidoTest extends TestCase
 {
     /**
      * @param string $paymentForm

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoSelloTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoSelloTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\TipoCadenaPagoSello;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class TipoCadenaPagoSelloTest extends TestCase
+final class TipoCadenaPagoSelloTest extends TestCase
 {
     /**
      * @param string|null $tipoCadPago

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoSelloTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoSelloTest.php
@@ -15,7 +15,7 @@ class TipoCadenaPagoSelloTest extends TestCase
      * @testWith [null, null]
      *           ["1", "1"]
      */
-    public function testValid($tipoCadPago, $input)
+    public function testValid(?string $tipoCadPago, ?string $input)
     {
         $pago = new Pago([
             'TipoCadPago' => $tipoCadPago,
@@ -36,7 +36,7 @@ class TipoCadenaPagoSelloTest extends TestCase
      *           [null, ""]
      *           ["", null]
      */
-    public function testInvalid($tipoCadPago, $input)
+    public function testInvalid(?string $tipoCadPago, ?string $input)
     {
         $pago = new Pago([
             'TipoCadPago' => $tipoCadPago,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCambioExistsTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCambioExistsTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\TipoCambioExists;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class TipoCambioExistsTest extends TestCase
+final class TipoCambioExistsTest extends TestCase
 {
     /**
      * @param string $currency

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCambioExistsTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCambioExistsTest.php
@@ -10,12 +10,12 @@ use PHPUnit\Framework\TestCase;
 class TipoCambioExistsTest extends TestCase
 {
     /**
-     * @param string|null $currency
+     * @param string $currency
      * @param string|null $exchangerate
      * @testWith ["MXN", null]
-     *           ["USD", 18.5678]
+     *           ["USD", "18.5678"]
      */
-    public function testValidInput($currency, $exchangerate)
+    public function testValidInput(string $currency, ?string $exchangerate)
     {
         $pago = new Pago([
             'MonedaP' => $currency,
@@ -26,14 +26,14 @@ class TipoCambioExistsTest extends TestCase
     }
 
     /**
-     * @param string|null $currency
+     * @param string $currency
      * @param string|null $exchangerate
      * @testWith ["MXN", "1"]
      *           ["MXN", "1.23"]
      *           ["USD", null]
      *           ["USD", ""]
      */
-    public function testInvalidInput($currency, $exchangerate)
+    public function testInvalidInput(string $currency, ?string $exchangerate)
     {
         $pago = new Pago([
             'MonedaP' => $currency,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCambioValueTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCambioValueTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\TipoCambioValue;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos\ValidatePagoException;
 use PHPUnit\Framework\TestCase;
 
-class TipoCambioValueTest extends TestCase
+final class TipoCambioValueTest extends TestCase
 {
     /**
      * @param string|null $exchangerate

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCambioValueTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCambioValueTest.php
@@ -15,7 +15,7 @@ class TipoCambioValueTest extends TestCase
      *           ["18.5623"]
      *           [null]
      */
-    public function testValid($exchangerate)
+    public function testValid(?string $exchangerate)
     {
         $pago = new Pago([
             'TipoCambioP' => $exchangerate,
@@ -25,14 +25,14 @@ class TipoCambioValueTest extends TestCase
     }
 
     /**
-     * @param string|null $exchangerate
+     * @param string $exchangerate
      * @testWith ["0.000001"]
      *           ["1.0000001"]
      *           ["-1"]
      *           ["not numeric"]
      *           [""]
      */
-    public function testInvalid($exchangerate)
+    public function testInvalid(string $exchangerate)
     {
         $pago = new Pago([
             'TipoCambioP' => $exchangerate,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/PagosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/PagosTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\Cfdi33\RecepcionPagos;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pagos;
 use CfdiUtils\Validate\Status;
 
-class PagosTest extends ValidateComplementoPagosTestCase
+final class PagosTest extends ValidateComplementoPagosTestCase
 {
     /** @var Pagos */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/PagosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/PagosTest.php
@@ -10,7 +10,7 @@ class PagosTest extends ValidateComplementoPagosTestCase
     /** @var Pagos */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new Pagos();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/SamplesTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/SamplesTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\CfdiValidator33;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\TestCase;
 
-class SamplesTest extends TestCase
+final class SamplesTest extends TestCase
 {
     /**
      * @param string $sampleName

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/SamplesTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/SamplesTest.php
@@ -19,7 +19,7 @@ class SamplesTest extends TestCase
      *           ["sample-validacfd04.xml"]
      *           ["sample-validacfd05.xml"]
      */
-    public function testSamplesFiles($sampleName)
+    public function testSamplesFiles(string $sampleName)
     {
         $sampleFile = $this->utilAsset('pagos10/' . $sampleName);
         $this->assertFileExists($sampleFile);

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/UsoCfdiTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/UsoCfdiTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\Cfdi33\RecepcionPagos;
 use CfdiUtils\Validate\Cfdi33\RecepcionPagos\UsoCfdi;
 use CfdiUtils\Validate\Status;
 
-class UsoCfdiTest extends ValidateComplementoPagosTestCase
+final class UsoCfdiTest extends ValidateComplementoPagosTestCase
 {
     /** @var UsoCfdi */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/UsoCfdiTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/UsoCfdiTest.php
@@ -10,7 +10,7 @@ class UsoCfdiTest extends ValidateComplementoPagosTestCase
     /** @var UsoCfdi */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new UsoCfdi();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ValidateComplementoPagosTestCase.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/RecepcionPagos/ValidateComplementoPagosTestCase.php
@@ -10,7 +10,7 @@ abstract class ValidateComplementoPagosTestCase extends ValidateTestCase
     /** @var Pagos10 */
     protected $complemento;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDecimalesMonedaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDecimalesMonedaTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ComprobanteDecimalesMoneda;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ComprobanteDecimalesMonedaTest extends ValidateTestCase
+final class ComprobanteDecimalesMonedaTest extends ValidateTestCase
 {
     /** @var ComprobanteDecimalesMoneda */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDecimalesMonedaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDecimalesMonedaTest.php
@@ -12,7 +12,7 @@ class ComprobanteDecimalesMonedaTest extends ValidateTestCase
     /** @var ComprobanteDecimalesMoneda */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComprobanteDecimalesMoneda();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDescuentoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDescuentoTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ComprobanteDescuento;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ComprobanteDescuentoTest extends ValidateTestCase
+final class ComprobanteDescuentoTest extends ValidateTestCase
 {
     /** @var ComprobanteDescuento */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDescuentoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDescuentoTest.php
@@ -11,7 +11,7 @@ class ComprobanteDescuentoTest extends ValidateTestCase
     /** @var ComprobanteDescuento */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComprobanteDescuento();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDescuentoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteDescuentoTest.php
@@ -17,7 +17,7 @@ class ComprobanteDescuentoTest extends ValidateTestCase
         $this->validator = new ComprobanteDescuento();
     }
 
-    public function providerValidCases()
+    public function providerValidCases(): array
     {
         return[
             ['0', '1'],
@@ -33,7 +33,7 @@ class ComprobanteDescuentoTest extends ValidateTestCase
      * @param string $subtotal
      * @dataProvider providerValidCases
      */
-    public function testValidCases($descuento, $subtotal)
+    public function testValidCases(string $descuento, string $subtotal)
     {
         $this->comprobante->addAttributes([
             'Descuento' => $descuento,
@@ -43,7 +43,7 @@ class ComprobanteDescuentoTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::ok(), 'DESCUENTO01');
     }
 
-    public function providerInvalidCases()
+    public function providerInvalidCases(): array
     {
         return[
             ['', '0'],
@@ -57,10 +57,10 @@ class ComprobanteDescuentoTest extends ValidateTestCase
 
     /**
      * @param string $descuento
-     * @param string $subtotal
+     * @param string|null $subtotal
      * @dataProvider providerInvalidCases
      */
-    public function testInvalidCases($descuento, $subtotal)
+    public function testInvalidCases(string $descuento, ?string $subtotal)
     {
         $this->comprobante->addAttributes([
             'Descuento' => $descuento,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteFormaPagoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteFormaPagoTest.php
@@ -12,7 +12,7 @@ class ComprobanteFormaPagoTest extends ValidateTestCase
     /** @var ComprobanteFormaPago */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComprobanteFormaPago();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteFormaPagoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteFormaPagoTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ComprobanteFormaPago;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ComprobanteFormaPagoTest extends ValidateTestCase
+final class ComprobanteFormaPagoTest extends ValidateTestCase
 {
     /** @var ComprobanteFormaPago */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteImpuestosTest.php
@@ -25,7 +25,7 @@ class ComprobanteImpuestosTest extends ValidateTestCase
      *           [false, true]
      *           [true, true]
      */
-    public function testValidImpuestos($putTraslados, $putRetenciones)
+    public function testValidImpuestos(bool $putTraslados, bool $putRetenciones)
     {
         $nodeImpuestos = new Node('cfdi:Impuestos');
         if ($putTraslados) {

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteImpuestosTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ComprobanteImpuestos;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ComprobanteImpuestosTest extends ValidateTestCase
+final class ComprobanteImpuestosTest extends ValidateTestCase
 {
     /** @var  ComprobanteImpuestos */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteImpuestosTest.php
@@ -12,7 +12,7 @@ class ComprobanteImpuestosTest extends ValidateTestCase
     /** @var  ComprobanteImpuestos */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComprobanteImpuestos();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoCambioTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoCambioTest.php
@@ -17,7 +17,7 @@ class ComprobanteTipoCambioTest extends ValidateTestCase
         $this->validator = new ComprobanteTipoCambio();
     }
 
-    public function providerMonedaWithValidValues()
+    public function providerMonedaWithValidValues(): array
     {
         return [
             ['MXN', '1', 'TIPOCAMBIO02', ['TIPOCAMBIO03', 'TIPOCAMBIO04']],
@@ -34,12 +34,12 @@ class ComprobanteTipoCambioTest extends ValidateTestCase
 
     /**
      * @param string $moneda
-     * @param mixed $tipoCambio
+     * @param string|null $tipoCambio
      * @param string $ok
      * @param string[] $nones
      * @dataProvider providerMonedaWithValidValues
      */
-    public function testMonedaWithValidValues($moneda, $tipoCambio, $ok, $nones)
+    public function testMonedaWithValidValues(string $moneda, ?string $tipoCambio, string $ok, array $nones)
     {
         $this->comprobante->addAttributes([
             'Moneda' => $moneda,
@@ -54,7 +54,7 @@ class ComprobanteTipoCambioTest extends ValidateTestCase
         }
     }
 
-    public function providerNoMonedaOrEmpty()
+    public function providerNoMonedaOrEmpty(): array
     {
         return [
             [null, null],
@@ -67,11 +67,11 @@ class ComprobanteTipoCambioTest extends ValidateTestCase
     }
 
     /**
-     * @param string $moneda
+     * @param string|null $moneda
      * @param string|null $tipoCambio
      * @dataProvider providerNoMonedaOrEmpty
      */
-    public function testNoMonedaOrEmpty($moneda, $tipoCambio)
+    public function testNoMonedaOrEmpty(?string $moneda, ?string $tipoCambio)
     {
         $this->comprobante->addAttributes([
             'Moneda' => $moneda,
@@ -85,7 +85,7 @@ class ComprobanteTipoCambioTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::none(), 'TIPOCAMBIO04');
     }
 
-    public function providerMonedaWithInvalidValues()
+    public function providerMonedaWithInvalidValues(): array
     {
         return [
             ['MXN', '', 'TIPOCAMBIO02', ['TIPOCAMBIO03', 'TIPOCAMBIO04']],
@@ -113,7 +113,7 @@ class ComprobanteTipoCambioTest extends ValidateTestCase
      * @param string[] $nones
      * @dataProvider providerMonedaWithInvalidValues
      */
-    public function testMonedaWithInvalidValues($moneda, $tipoCambio, $error, $nones)
+    public function testMonedaWithInvalidValues(string $moneda, ?string $tipoCambio, string $error, array $nones)
     {
         $this->comprobante->addAttributes([
             'Moneda' => $moneda,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoCambioTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoCambioTest.php
@@ -11,7 +11,7 @@ class ComprobanteTipoCambioTest extends ValidateTestCase
     /** @var ComprobanteTipoCambio */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComprobanteTipoCambio();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoCambioTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoCambioTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ComprobanteTipoCambio;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ComprobanteTipoCambioTest extends ValidateTestCase
+final class ComprobanteTipoCambioTest extends ValidateTestCase
 {
     /** @var ComprobanteTipoCambio */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
@@ -18,7 +18,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
         $this->validator = new ComprobanteTipoDeComprobante();
     }
 
-    public function providerTPN()
+    public function providerTPN(): array
     {
         return [['T'], ['P'], ['N']];
     }
@@ -27,7 +27,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
      * @param string $tipoDeComprobante
      * @dataProvider providerTPN
      */
-    public function testValidTPN($tipoDeComprobante)
+    public function testValidTPN(string $tipoDeComprobante)
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,
@@ -41,7 +41,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
      * @param string $tipoDeComprobante
      * @dataProvider providerTPN
      */
-    public function testInvalidTPN($tipoDeComprobante)
+    public function testInvalidTPN(string $tipoDeComprobante)
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,
@@ -55,7 +55,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'TIPOCOMP02');
     }
 
-    public function providerTP()
+    public function providerTP(): array
     {
         return [['T'], ['P']];
     }
@@ -64,7 +64,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
      * @param string $tipoDeComprobante
      * @dataProvider providerTP
      */
-    public function testValidTP($tipoDeComprobante)
+    public function testValidTP(string $tipoDeComprobante)
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,
@@ -117,7 +117,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'TIPOCOMP06');
     }
 
-    public function providerTPNonZero()
+    public function providerTPNonZero(): array
     {
         $types = [
             ['T'],
@@ -138,7 +138,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
      * @param string|null $subtotal
      * @dataProvider providerTPNonZero
      */
-    public function testInvalidSubTotal($tipoDeComprobante, $subtotal)
+    public function testInvalidSubTotal(string $tipoDeComprobante, ?string $subtotal)
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,
@@ -153,7 +153,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
      * @param string|null $total
      * @dataProvider providerTPNonZero
      */
-    public function testInvalidTotal($tipoDeComprobante, $total)
+    public function testInvalidTotal(string $tipoDeComprobante, ?string $total)
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,
@@ -163,7 +163,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'TIPOCOMP08');
     }
 
-    public function providerIEN()
+    public function providerIEN(): array
     {
         return [['I'], ['E'], ['N']];
     }
@@ -172,7 +172,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
      * @param string $tipoDeComprobante
      * @dataProvider providerIEN
      */
-    public function testValidIENValorUnitarioGreaterThanZero($tipoDeComprobante)
+    public function testValidIENValorUnitarioGreaterThanZero(string $tipoDeComprobante)
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,
@@ -185,7 +185,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::ok(), 'TIPOCOMP09');
     }
 
-    public function providerIENWrongValue()
+    public function providerIENWrongValue(): array
     {
         return $this->providerFullJoin(
             $this->providerIEN(),
@@ -198,7 +198,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
      * @param string|null $wrongUnitValue
      * @dataProvider providerIENWrongValue
      */
-    public function testInvalidIENValorUnitarioGreaterThanZero($tipoDeComprobante, $wrongUnitValue)
+    public function testInvalidIENValorUnitarioGreaterThanZero(string $tipoDeComprobante, ?string $wrongUnitValue)
     {
         $this->comprobante->addAttributes([
             'TipoDeComprobante' => $tipoDeComprobante,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ComprobanteTipoDeComprobante;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
+final class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
 {
     /** @var  ComprobanteTipoDeComprobante */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTipoDeComprobanteTest.php
@@ -12,7 +12,7 @@ class ComprobanteTipoDeComprobanteTest extends ValidateTestCase
     /** @var  ComprobanteTipoDeComprobante */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComprobanteTipoDeComprobante();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTotalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTotalTest.php
@@ -11,7 +11,7 @@ class ComprobanteTotalTest extends ValidateTestCase
     /** @var ComprobanteTotal */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ComprobanteTotal();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTotalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTotalTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ComprobanteTotal;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ComprobanteTotalTest extends ValidateTestCase
+final class ComprobanteTotalTest extends ValidateTestCase
 {
     /** @var ComprobanteTotal */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTotalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ComprobanteTotalTest.php
@@ -17,7 +17,7 @@ class ComprobanteTotalTest extends ValidateTestCase
         $this->validator = new ComprobanteTotal();
     }
 
-    public function providerTotalWithInvalidValue()
+    public function providerTotalWithInvalidValue(): array
     {
         return [
             'empty' => [''],
@@ -36,7 +36,7 @@ class ComprobanteTotalTest extends ValidateTestCase
      * @param string|null $value
      * @dataProvider providerTotalWithInvalidValue
      */
-    public function testTotalWithInvalidValue($value)
+    public function testTotalWithInvalidValue(?string $value)
     {
         $this->comprobante->addAttributes([
             'Total' => $value,
@@ -46,7 +46,7 @@ class ComprobanteTotalTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'TOTAL01');
     }
 
-    public function providerTotalWithValidValues()
+    public function providerTotalWithValidValues(): array
     {
         return [
             '0' => ['0'],
@@ -56,10 +56,10 @@ class ComprobanteTotalTest extends ValidateTestCase
     }
 
     /**
-     * @param string|null $value
+     * @param string $value
      * @dataProvider providerTotalWithValidValues
      */
-    public function testTotalWithCorrectValues($value)
+    public function testTotalWithCorrectValues(string $value)
     {
         $this->comprobante->addAttributes([
             'Total' => $value,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoDescuentoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoDescuentoTest.php
@@ -11,7 +11,7 @@ class ConceptoDescuentoTest extends ValidateTestCase
     /** @var ConceptoDescuento */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ConceptoDescuento();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoDescuentoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoDescuentoTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ConceptoDescuento;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ConceptoDescuentoTest extends ValidateTestCase
+final class ConceptoDescuentoTest extends ValidateTestCase
 {
     /** @var ConceptoDescuento */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoDescuentoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoDescuentoTest.php
@@ -17,7 +17,7 @@ class ConceptoDescuentoTest extends ValidateTestCase
         $this->validator = new ConceptoDescuento();
     }
 
-    public function providerValidCases()
+    public function providerValidCases(): array
     {
         return[
             ['', '0'],
@@ -34,7 +34,7 @@ class ConceptoDescuentoTest extends ValidateTestCase
      * @param string $importe
      * @dataProvider providerValidCases
      */
-    public function testValidCases($descuento, $importe)
+    public function testValidCases(string $descuento, string $importe)
     {
         $this->getComprobante()->addConcepto([
             'Descuento' => $descuento,
@@ -44,7 +44,7 @@ class ConceptoDescuentoTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::ok(), 'CONCEPDESC01');
     }
 
-    public function providerInvalidCases()
+    public function providerInvalidCases(): array
     {
         return[
             ['1', '0'],
@@ -57,10 +57,10 @@ class ConceptoDescuentoTest extends ValidateTestCase
 
     /**
      * @param string $descuento
-     * @param string $importe
+     * @param string|null $importe
      * @dataProvider providerInvalidCases
      */
-    public function testInvalidCases($descuento, $importe)
+    public function testInvalidCases(string $descuento, ?string $importe)
     {
         $this->getComprobante()->addConcepto(['Descuento' => '1', 'Importe' => '2']);
         $concepto = $this->getComprobante()->addConcepto([

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoImpuestosTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ConceptoImpuestos;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ConceptoImpuestosTest extends ValidateTestCase
+final class ConceptoImpuestosTest extends ValidateTestCase
 {
     /** @var ConceptoImpuestos */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoImpuestosTest.php
@@ -26,9 +26,9 @@ class ConceptoImpuestosTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'CONCEPIMPC01');
     }
 
-    public function providerInvalidBaseTraslado()
+    public function providerInvalidBaseTraslado(): array
     {
-        return[
+        return [
             ['0'],
             ['0.0000001'],
             ['-1'],
@@ -41,7 +41,7 @@ class ConceptoImpuestosTest extends ValidateTestCase
      * @param string $base
      * @dataProvider providerInvalidBaseTraslado
      */
-    public function testTrasladoHasBaseGreaterThanZeroInvalidCase($base)
+    public function testTrasladoHasBaseGreaterThanZeroInvalidCase(string $base)
     {
         $comprobante = $this->validComprobante();
         $comprobante->addConcepto()->addTraslado(['Base' => $base]);
@@ -49,7 +49,7 @@ class ConceptoImpuestosTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'CONCEPIMPC02');
     }
 
-    public function providerTrasladoTipoFactorExento()
+    public function providerTrasladoTipoFactorExento(): array
     {
         return[
             ['1', '1'],
@@ -63,7 +63,7 @@ class ConceptoImpuestosTest extends ValidateTestCase
      * @param string|null $importe
      * @dataProvider providerTrasladoTipoFactorExento
      */
-    public function testTrasladoTipoFactorExentoInvalidCase($tasaOCuota, $importe)
+    public function testTrasladoTipoFactorExentoInvalidCase(?string $tasaOCuota, ?string $importe)
     {
         $comprobante = $this->validComprobante();
         $comprobante->addConcepto()->addTraslado([
@@ -75,7 +75,7 @@ class ConceptoImpuestosTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'CONCEPIMPC03');
     }
 
-    public function providerTrasladosTipoFactorTasaOCuotaInvalidCase()
+    public function providerTrasladosTipoFactorTasaOCuotaInvalidCase(): array
     {
         return $this->providerFullJoin(
             [['Tasa'], ['Cuota']], // tipoFactor
@@ -90,8 +90,11 @@ class ConceptoImpuestosTest extends ValidateTestCase
      * @param string|null $importe
      * @dataProvider providerTrasladosTipoFactorTasaOCuotaInvalidCase
      */
-    public function testTrasladosTipoFactorTasaOCuotaInvalidCase($tipoFactor, $tasaOCuota, $importe)
-    {
+    public function testTrasladosTipoFactorTasaOCuotaInvalidCase(
+        string $tipoFactor,
+        ?string $tasaOCuota,
+        ?string $importe
+    ) {
         $comprobante = $this->validComprobante();
         $comprobante->addConcepto()->addTraslado([
             'TipoFactor' => $tipoFactor,
@@ -102,7 +105,7 @@ class ConceptoImpuestosTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'CONCEPIMPC04');
     }
 
-    public function providerInvalidBaseRetencion()
+    public function providerInvalidBaseRetencion(): array
     {
         return[
             ['0'],
@@ -117,7 +120,7 @@ class ConceptoImpuestosTest extends ValidateTestCase
      * @param string $base
      * @dataProvider providerInvalidBaseTraslado
      */
-    public function testRetencionesHasBaseGreaterThanZeroInvalidCase($base)
+    public function testRetencionesHasBaseGreaterThanZeroInvalidCase(string $base)
     {
         $comprobante = $this->validComprobante();
         $comprobante->addConcepto()->addRetencion(['Base' => $base]);

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ConceptoImpuestosTest.php
@@ -12,7 +12,7 @@ class ConceptoImpuestosTest extends ValidateTestCase
     /** @var ConceptoImpuestos */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ConceptoImpuestos();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\EmisorRegimenFiscal;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class EmisorRegimenFiscalTest extends ValidateTestCase
+final class EmisorRegimenFiscalTest extends ValidateTestCase
 {
     /** @var  EmisorRegimenFiscal */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
@@ -18,7 +18,7 @@ class EmisorRegimenFiscalTest extends ValidateTestCase
         $this->validator = new EmisorRegimenFiscal();
     }
 
-    public function providerValidCases()
+    public function providerValidCases(): array
     {
         return[
             // personas morales
@@ -58,7 +58,7 @@ class EmisorRegimenFiscalTest extends ValidateTestCase
      * @param string $regimenFiscal
      * @dataProvider providerValidCases
      */
-    public function testValidCases($emisorRfc, $regimenFiscal)
+    public function testValidCases(string $emisorRfc, string $regimenFiscal)
     {
         $this->comprobante->addChild(new Node('cfdi:Emisor', [
             'RegimenFiscal' => $regimenFiscal,
@@ -69,7 +69,7 @@ class EmisorRegimenFiscalTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::ok(), 'REGFIS01');
     }
 
-    public function providerInvalidCases()
+    public function providerInvalidCases(): array
     {
         return [
             ['AAA010101AAA', '605'], // persona moral con regimen incorrecto
@@ -83,11 +83,11 @@ class EmisorRegimenFiscalTest extends ValidateTestCase
     }
 
     /**
-     * @param string $emisorRfc
-     * @param string $regimenFiscal
+     * @param string|null $emisorRfc
+     * @param string|null $regimenFiscal
      * @dataProvider providerInvalidCases
      */
-    public function testInvalidCases($emisorRfc, $regimenFiscal)
+    public function testInvalidCases(?string $emisorRfc, ?string $regimenFiscal)
     {
         $this->comprobante->addChild(new Node('cfdi:Emisor', [
             'RegimenFiscal' => $regimenFiscal,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
@@ -12,7 +12,7 @@ class EmisorRegimenFiscalTest extends ValidateTestCase
     /** @var  EmisorRegimenFiscal */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new EmisorRegimenFiscal();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRfcTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRfcTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\EmisorRfc;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class EmisorRfcTest extends ValidateTestCase
+final class EmisorRfcTest extends ValidateTestCase
 {
     /** @var EmisorRfc */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRfcTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRfcTest.php
@@ -13,7 +13,7 @@ class EmisorRfcTest extends ValidateTestCase
     /** @var EmisorRfc */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new EmisorRfc();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRfcTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRfcTest.php
@@ -19,7 +19,7 @@ class EmisorRfcTest extends ValidateTestCase
         $this->validator = new EmisorRfc();
     }
 
-    public function providerValidCases()
+    public function providerValidCases(): array
     {
         return [
             'person' => ['COSC8001137NA'],
@@ -41,7 +41,7 @@ class EmisorRfcTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::ok(), 'EMISORRFC01');
     }
 
-    public function providerInvalidCases()
+    public function providerInvalidCases(): array
     {
         return [
             'none' => [null],
@@ -53,10 +53,10 @@ class EmisorRfcTest extends ValidateTestCase
     }
 
     /**
-     * @param string $rfc
+     * @param string|null $rfc
      * @dataProvider providerInvalidCases
      */
-    public function testInvalidCases($rfc)
+    public function testInvalidCases(?string $rfc)
     {
         $this->comprobante->addChild(new Node('cfdi:Emisor', [
             'Rfc' => $rfc,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/FechaComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/FechaComprobanteTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\FechaComprobante;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class FechaComprobanteTest extends ValidateTestCase
+final class FechaComprobanteTest extends ValidateTestCase
 {
     /** @var FechaComprobante */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/FechaComprobanteTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/FechaComprobanteTest.php
@@ -12,7 +12,7 @@ class FechaComprobanteTest extends ValidateTestCase
     /** @var FechaComprobante */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new FechaComprobante();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorResidenciaFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorResidenciaFiscalTest.php
@@ -18,7 +18,7 @@ class ReceptorResidenciaFiscalTest extends ValidateTestCase
         $this->validator = new ReceptorResidenciaFiscal();
     }
 
-    public function providerValidCases()
+    public function providerValidCases(): array
     {
         return [
             // RESFISC01: Si el RFC no es XEXX010101000 entonces la residencia fiscal no debe existir
@@ -35,15 +35,20 @@ class ReceptorResidenciaFiscalTest extends ValidateTestCase
     }
 
     /**
-     * @param mixed $receptorRfc
-     * @param mixed $residenciaFiscal
-     * @param mixed $numRegIdTrib
-     * @param mixed $putComercioExterior
+     * @param string|null $receptorRfc
+     * @param string|null $residenciaFiscal
+     * @param string|null $numRegIdTrib
+     * @param bool $putComercioExterior
      * @param string $ok
      * @dataProvider providerValidCases
      */
-    public function testValidCase($receptorRfc, $residenciaFiscal, $numRegIdTrib, $putComercioExterior, $ok)
-    {
+    public function testValidCase(
+        ?string $receptorRfc,
+        ?string $residenciaFiscal,
+        ?string $numRegIdTrib,
+        bool $putComercioExterior,
+        string $ok
+    ) {
         $this->comprobante->addChild(new Node('cfdi:Receptor', [
             'Rfc' => $receptorRfc,
             'ResidenciaFiscal' => $residenciaFiscal,
@@ -59,7 +64,7 @@ class ReceptorResidenciaFiscalTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::ok(), $ok);
     }
 
-    public function providerInvalidCases()
+    public function providerInvalidCases(): array
     {
         return [
             // RESFISC01: Si el RFC no es XEXX010101000 entonces la residencia fiscal no debe existir
@@ -83,15 +88,20 @@ class ReceptorResidenciaFiscalTest extends ValidateTestCase
     }
 
     /**
-     * @param mixed $receptorRfc
-     * @param mixed $residenciaFiscal
-     * @param mixed $numRegIdTrib
+     * @param string|null $receptorRfc
+     * @param string|null $residenciaFiscal
+     * @param string|null $numRegIdTrib
      * @param bool $putComercioExterior
      * @param string $error
-     * @dataProvider providerinValidCases
+     * @dataProvider providerInvalidCases
      */
-    public function testInvalidCase($receptorRfc, $residenciaFiscal, $numRegIdTrib, $putComercioExterior, $error)
-    {
+    public function testInvalidCase(
+        ?string $receptorRfc,
+        ?string $residenciaFiscal,
+        ?string $numRegIdTrib,
+        bool $putComercioExterior,
+        string $error
+    ) {
         $this->comprobante->addChild(new Node('cfdi:Receptor', [
             'Rfc' => $receptorRfc,
             'ResidenciaFiscal' => $residenciaFiscal,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorResidenciaFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorResidenciaFiscalTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ReceptorResidenciaFiscal;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ReceptorResidenciaFiscalTest extends ValidateTestCase
+final class ReceptorResidenciaFiscalTest extends ValidateTestCase
 {
     /** @var  ReceptorResidenciaFiscal */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorResidenciaFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorResidenciaFiscalTest.php
@@ -12,7 +12,7 @@ class ReceptorResidenciaFiscalTest extends ValidateTestCase
     /** @var  ReceptorResidenciaFiscal */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ReceptorResidenciaFiscal();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorRfcTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorRfcTest.php
@@ -19,7 +19,7 @@ class ReceptorRfcTest extends ValidateTestCase
         $this->validator = new ReceptorRfc();
     }
 
-    public function providerValidCases()
+    public function providerValidCases(): array
     {
         return [
             'generic' => [Rfc::RFC_GENERIC],
@@ -43,7 +43,7 @@ class ReceptorRfcTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::ok(), 'RECRFC01');
     }
 
-    public function providerInvalidCases()
+    public function providerInvalidCases(): array
     {
         return [
             'none' => [null],
@@ -53,10 +53,10 @@ class ReceptorRfcTest extends ValidateTestCase
     }
 
     /**
-     * @param string $rfc
+     * @param string|null $rfc
      * @dataProvider providerInvalidCases
      */
-    public function testInvalidCases($rfc)
+    public function testInvalidCases(?string $rfc)
     {
         $this->comprobante->addChild(new Node('cfdi:Receptor', [
             'Rfc' => $rfc,

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorRfcTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorRfcTest.php
@@ -13,7 +13,7 @@ class ReceptorRfcTest extends ValidateTestCase
     /** @var ReceptorRfc */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new ReceptorRfc();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorRfcTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/ReceptorRfcTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\ReceptorRfc;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class ReceptorRfcTest extends ValidateTestCase
+final class ReceptorRfcTest extends ValidateTestCase
 {
     /** @var ReceptorRfc */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoTest.php
@@ -12,7 +12,7 @@ use CfdiUtils\Validate\Contracts\RequireXmlStringInterface;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class SelloDigitalCertificadoTest extends ValidateTestCase
+final class SelloDigitalCertificadoTest extends ValidateTestCase
 {
     /** @var SelloDigitalCertificado */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoTest.php
@@ -17,7 +17,7 @@ class SelloDigitalCertificadoTest extends ValidateTestCase
     /** @var SelloDigitalCertificado */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new SelloDigitalCertificado();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoWithCfdiRegistroFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoWithCfdiRegistroFiscalTest.php
@@ -11,7 +11,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\SelloDigitalCertificado;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class SelloDigitalCertificadoWithCfdiRegistroFiscalTest extends ValidateTestCase
+final class SelloDigitalCertificadoWithCfdiRegistroFiscalTest extends ValidateTestCase
 {
     /** @var SelloDigitalCertificado */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoWithCfdiRegistroFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoWithCfdiRegistroFiscalTest.php
@@ -16,7 +16,7 @@ class SelloDigitalCertificadoWithCfdiRegistroFiscalTest extends ValidateTestCase
     /** @var SelloDigitalCertificado */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new SelloDigitalCertificado();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SumasConceptosComprobanteImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SumasConceptosComprobanteImpuestosTest.php
@@ -206,7 +206,7 @@ class SumasConceptosComprobanteImpuestosTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::error(), 'SUMAS11');
     }
 
-    public function providerValidateDescuentoLessOrEqualThanSubTotal()
+    public function providerValidateDescuentoLessOrEqualThanSubTotal(): array
     {
         return [
             'greater' => ['12345.679', '12345.678', Status::error()],

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SumasConceptosComprobanteImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SumasConceptosComprobanteImpuestosTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Contracts\DiscoverableCreateInterface;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class SumasConceptosComprobanteImpuestosTest extends ValidateTestCase
+final class SumasConceptosComprobanteImpuestosTest extends ValidateTestCase
 {
     /** @var SumasConceptosComprobanteImpuestos */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SumasConceptosComprobanteImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SumasConceptosComprobanteImpuestosTest.php
@@ -13,7 +13,7 @@ class SumasConceptosComprobanteImpuestosTest extends ValidateTestCase
     /** @var SumasConceptosComprobanteImpuestos */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new SumasConceptosComprobanteImpuestos();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalSelloTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalSelloTest.php
@@ -9,7 +9,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\TimbreFiscalDigitalSello;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class TimbreFiscalDigitalSelloTest extends ValidateTestCase
+final class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 {
     /** @var TimbreFiscalDigitalSello */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalSelloTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalSelloTest.php
@@ -14,7 +14,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
     /** @var TimbreFiscalDigitalSello */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new TimbreFiscalDigitalSello();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalSelloTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalSelloTest.php
@@ -46,14 +46,14 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
         $this->validator->setXmlResolver(null);
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::none(), 'TFDSELLO01');
-        $this->assertContains('No se puede hacer la validación', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString('No se puede hacer la validación', $this->asserts->get('TFDSELLO01')->getExplanation());
     }
 
     public function testValidatorDontHaveTimbreFiscalDigital()
     {
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::none(), 'TFDSELLO01');
-        $this->assertContains('no contiene un Timbre', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString('no contiene un Timbre', $this->asserts->get('TFDSELLO01')->getExplanation());
     }
 
     public function testValidatorTimbreFiscalDigitalVersionIsNotPresent()
@@ -64,7 +64,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::none(), 'TFDSELLO01');
-        $this->assertContains('La versión del timbre', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString('La versión del timbre', $this->asserts->get('TFDSELLO01')->getExplanation());
     }
 
     public function testValidatorTimbreFiscalDigitalVersionIsNotValid()
@@ -75,7 +75,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::none(), 'TFDSELLO01');
-        $this->assertContains('La versión del timbre', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString('La versión del timbre', $this->asserts->get('TFDSELLO01')->getExplanation());
     }
 
     public function testValidatorTimbreFiscalDigitalSelloSatDoesNotMatchWithComprobante()
@@ -86,7 +86,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::error(), 'TFDSELLO01');
-        $this->assertContains('no coincide', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString('no coincide', $this->asserts->get('TFDSELLO01')->getExplanation());
     }
 
     public function testValidatorNoCertificadoSatEmpty()
@@ -98,7 +98,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::error(), 'TFDSELLO01');
-        $this->assertContains('NoCertificadoSAT', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString('NoCertificadoSAT', $this->asserts->get('TFDSELLO01')->getExplanation());
     }
 
     public function testValidatorNoCertificadoSatInvalid()
@@ -111,7 +111,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::error(), 'TFDSELLO01');
-        $this->assertContains('NoCertificadoSAT', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString('NoCertificadoSAT', $this->asserts->get('TFDSELLO01')->getExplanation());
     }
 
     public function testValidatorNoCertificadoSatNonExistent()
@@ -124,7 +124,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::error(), 'TFDSELLO01');
-        $this->assertContains('obtener el certificado', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString('obtener el certificado', $this->asserts->get('TFDSELLO01')->getExplanation());
     }
 
     public function testValidatorSelloSatInvalid()
@@ -146,7 +146,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::error(), 'TFDSELLO01');
-        $this->assertContains(
+        $this->assertStringContainsString(
             'La verificación del timbrado fue negativa',
             $this->asserts->get('TFDSELLO01')->getExplanation()
         );
@@ -157,12 +157,12 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
         return new TimbreFiscalDigital($attributes);
     }
 
-    private function validCertificadoSAT()
+    private function validCertificadoSAT(): string
     {
         return '00001000000406258094';
     }
 
-    private function validSelloCfdi()
+    private function validSelloCfdi(): string
     {
         return 'Xt7tK83WumikNMyx4Y/Z3R7D0rOjqTrrLu8wBlCnvXrpMFgWtyrcFUttGnevvUqCnQjuVUSpFcXqbzIQEUYNKFjxmtjwGHN+b'
             . '15xUvcnfqpJRBoJe2IKd5YMZqYp9NhTJIMBYsE7+fhP1+mHcKdKn9WwXrar8uXzISqPgZ97AORBsMWmXxbVWYRtqT4MX/Xq4yhbT4jao'
@@ -170,7 +170,7 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
             . 'ks7qC+eO3EsGVr1/ntmGcwTurbGXmE4/OAgdg==';
     }
 
-    private function validSelloSat()
+    private function validSelloSat(): string
     {
         return 'IRy7wQnKnlIsN/pSZSR7qEm/SOJuLIbNjj/S3EAd278T2uo0t73KXfXzUbbfWOwpdZEAZeosq/yEiStTaf44ZonqRS1fq6oYk1'
             . '2udMmT4NFrEYbPEEKLn4lqdhuW4v8ZK2Vos/pjCtYtpT+/oVIXiWg9KrGVGuMvygRPWSmd+YJq3Jm7qTz0ON0vzBOvXralSZ4Q14xUvt'

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalSelloTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalSelloTest.php
@@ -46,7 +46,10 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
         $this->validator->setXmlResolver(null);
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::none(), 'TFDSELLO01');
-        $this->assertStringContainsString('No se puede hacer la validación', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString(
+            'No se puede hacer la validación',
+            $this->asserts->get('TFDSELLO01')->getExplanation()
+        );
     }
 
     public function testValidatorDontHaveTimbreFiscalDigital()
@@ -124,7 +127,10 @@ class TimbreFiscalDigitalSelloTest extends ValidateTestCase
 
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::error(), 'TFDSELLO01');
-        $this->assertStringContainsString('obtener el certificado', $this->asserts->get('TFDSELLO01')->getExplanation());
+        $this->assertStringContainsString(
+            'obtener el certificado',
+            $this->asserts->get('TFDSELLO01')->getExplanation()
+        );
     }
 
     public function testValidatorSelloSatInvalid()

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalVersionTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalVersionTest.php
@@ -30,7 +30,7 @@ class TimbreFiscalDigitalVersionTest extends ValidateTestCase
         $this->assertStatusEqualsCode(Status::ok(), 'TFDVERSION01');
     }
 
-    public function providerInvalidVersion()
+    public function providerInvalidVersion(): array
     {
         return[
             ['1.0'],
@@ -48,7 +48,7 @@ class TimbreFiscalDigitalVersionTest extends ValidateTestCase
      * @param string|null $version
      * @dataProvider providerInvalidVersion
      */
-    public function testInvalidCase($version)
+    public function testInvalidCase(?string $version)
     {
         $tfd = new TimbreFiscalDigital();
         $tfd->addAttributes(['Version' => $version]); // override version

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalVersionTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalVersionTest.php
@@ -16,7 +16,7 @@ class TimbreFiscalDigitalVersionTest extends ValidateTestCase
     /** @var  TimbreFiscalDigitalVersion */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new TimbreFiscalDigitalVersion();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalVersionTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/TimbreFiscalDigitalVersionTest.php
@@ -8,7 +8,7 @@ use CfdiUtils\Validate\Cfdi33\Standard\TimbreFiscalDigitalVersion;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class TimbreFiscalDigitalVersionTest extends ValidateTestCase
+final class TimbreFiscalDigitalVersionTest extends ValidateTestCase
 {
     /* @var \CfdiUtils\Elements\Cfdi33\Comprobante */
     protected $comprobante;

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Xml/XmlFollowSchemaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Xml/XmlFollowSchemaTest.php
@@ -12,7 +12,7 @@ class XmlFollowSchemaTest extends ValidateTestCase
     /** @var XmlFollowSchema */
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->validator = new XmlFollowSchema();

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Xml/XmlFollowSchemaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Xml/XmlFollowSchemaTest.php
@@ -39,7 +39,7 @@ class XmlFollowSchemaTest extends ValidateTestCase
         $this->comprobante = $comprobante;
         $this->runValidate();
         $this->assertStatusEqualsCode(Status::error(), 'XSD01');
-        $this->assertContains('Emisor', $this->asserts->get('XSD01')->getExplanation());
+        $this->assertStringContainsString('Emisor', $this->asserts->get('XSD01')->getExplanation());
     }
 
     public function testWithXsdUriNotFound()

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Xml/XmlFollowSchemaTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Xml/XmlFollowSchemaTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Cfdi33\Xml\XmlFollowSchema;
 use CfdiUtils\Validate\Status;
 use CfdiUtilsTests\Validate\ValidateTestCase;
 
-class XmlFollowSchemaTest extends ValidateTestCase
+final class XmlFollowSchemaTest extends ValidateTestCase
 {
     /** @var XmlFollowSchema */
     protected $validator;

--- a/tests/CfdiUtilsTests/Validate/DiscovererTest.php
+++ b/tests/CfdiUtilsTests/Validate/DiscovererTest.php
@@ -6,7 +6,7 @@ use CfdiUtils\Validate\Contracts\ValidatorInterface;
 use CfdiUtils\Validate\Discoverer;
 use PHPUnit\Framework\TestCase;
 
-class DiscovererTest extends TestCase
+final class DiscovererTest extends TestCase
 {
     public function testDiscoverInFolder()
     {

--- a/tests/CfdiUtilsTests/Validate/FakeObjects/ImplementationDiscoverableCreateInterface.php
+++ b/tests/CfdiUtilsTests/Validate/FakeObjects/ImplementationDiscoverableCreateInterface.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\FakeObjects;
 use CfdiUtils\Validate\Contracts\DiscoverableCreateInterface;
 use CfdiUtils\Validate\Contracts\ValidatorInterface;
 
-class ImplementationDiscoverableCreateInterface implements DiscoverableCreateInterface
+final class ImplementationDiscoverableCreateInterface implements DiscoverableCreateInterface
 {
     public static function createDiscovered(): ValidatorInterface
     {

--- a/tests/CfdiUtilsTests/Validate/FakeObjects/ImplementationRequireXmlResolverInterface.php
+++ b/tests/CfdiUtilsTests/Validate/FakeObjects/ImplementationRequireXmlResolverInterface.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\FakeObjects;
 use CfdiUtils\Validate\Contracts\RequireXmlResolverInterface;
 use CfdiUtils\XmlResolver\XmlResolverPropertyTrait;
 
-class ImplementationRequireXmlResolverInterface extends ImplementationValidatorInterface implements
+final class ImplementationRequireXmlResolverInterface extends ImplementationValidatorInterface implements
     RequireXmlResolverInterface
 {
     use XmlResolverPropertyTrait;

--- a/tests/CfdiUtilsTests/Validate/FakeObjects/ImplementationRequireXmlStringInterface.php
+++ b/tests/CfdiUtilsTests/Validate/FakeObjects/ImplementationRequireXmlStringInterface.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate\FakeObjects;
 use CfdiUtils\Validate\Contracts\RequireXmlStringInterface;
 use CfdiUtils\Validate\Traits\XmlStringPropertyTrait;
 
-class ImplementationRequireXmlStringInterface extends ImplementationValidatorInterface implements
+final class ImplementationRequireXmlStringInterface extends ImplementationValidatorInterface implements
     RequireXmlStringInterface
 {
     use XmlStringPropertyTrait;

--- a/tests/CfdiUtilsTests/Validate/FakeObjects/ImplementationValidatorInterface.php
+++ b/tests/CfdiUtilsTests/Validate/FakeObjects/ImplementationValidatorInterface.php
@@ -18,7 +18,7 @@ class ImplementationValidatorInterface implements ValidatorInterface
     public $enterValidateMethod = false;
 
     /** @var Asserts|null */
-    public $assertsToImport = null;
+    public $assertsToImport;
 
     public function validate(NodeInterface $comprobante, Asserts $asserts)
     {

--- a/tests/CfdiUtilsTests/Validate/HydraterTest.php
+++ b/tests/CfdiUtilsTests/Validate/HydraterTest.php
@@ -7,7 +7,7 @@ use CfdiUtilsTests\TestCase;
 use CfdiUtilsTests\Validate\FakeObjects\ImplementationRequireXmlResolverInterface;
 use CfdiUtilsTests\Validate\FakeObjects\ImplementationRequireXmlStringInterface;
 
-class HydraterTest extends TestCase
+final class HydraterTest extends TestCase
 {
     public function testHydrateXmlString()
     {

--- a/tests/CfdiUtilsTests/Validate/MultiValidatorFactoryTest.php
+++ b/tests/CfdiUtilsTests/Validate/MultiValidatorFactoryTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\Validate\Discoverer;
 use CfdiUtils\Validate\MultiValidatorFactory;
 use PHPUnit\Framework\TestCase;
 
-class MultiValidatorFactoryTest extends TestCase
+final class MultiValidatorFactoryTest extends TestCase
 {
     public function testConstructWithoutArguments()
     {

--- a/tests/CfdiUtilsTests/Validate/MultiValidatorTest.php
+++ b/tests/CfdiUtilsTests/Validate/MultiValidatorTest.php
@@ -12,7 +12,7 @@ use CfdiUtilsTests\Validate\FakeObjects\ImplementationRequireXmlResolverInterfac
 use CfdiUtilsTests\Validate\FakeObjects\ImplementationRequireXmlStringInterface;
 use CfdiUtilsTests\Validate\FakeObjects\ImplementationValidatorInterface;
 
-class MultiValidatorTest extends TestCase
+final class MultiValidatorTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/CfdiUtilsTests/Validate/StatusTest.php
+++ b/tests/CfdiUtilsTests/Validate/StatusTest.php
@@ -5,7 +5,7 @@ namespace CfdiUtilsTests\Validate;
 use CfdiUtils\Validate\Status;
 use PHPUnit\Framework\TestCase;
 
-class StatusTest extends TestCase
+final class StatusTest extends TestCase
 {
     public function testConstructWithInvalidCode()
     {

--- a/tests/CfdiUtilsTests/Validate/ValidateTestCase.php
+++ b/tests/CfdiUtilsTests/Validate/ValidateTestCase.php
@@ -60,7 +60,7 @@ abstract class ValidateTestCase extends TestCase
             $this->fail("Did not receive actual status for code '$code', it may not exists");
         }
         $actualAssert = $this->asserts->get($code);
-        $this->assertContains($expected, $actualAssert->getExplanation());
+        $this->assertStringContainsString($expected, $actualAssert->getExplanation());
     }
 
     protected function getAssertByCodeOrFail(string $code): Assert

--- a/tests/CfdiUtilsTests/Validate/ValidateTestCase.php
+++ b/tests/CfdiUtilsTests/Validate/ValidateTestCase.php
@@ -27,7 +27,7 @@ abstract class ValidateTestCase extends TestCase
     /** @var Hydrater */
     protected $hydrater;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->comprobante = new Comprobante();

--- a/tests/CfdiUtilsTests/Validate/ValidateTestCase.php
+++ b/tests/CfdiUtilsTests/Validate/ValidateTestCase.php
@@ -58,7 +58,6 @@ abstract class ValidateTestCase extends TestCase
     {
         if (! $this->asserts->exists($code)) {
             $this->fail("Did not receive actual status for code '$code', it may not exists");
-            return;
         }
         $actualAssert = $this->asserts->get($code);
         $this->assertContains($expected, $actualAssert->getExplanation());
@@ -68,7 +67,6 @@ abstract class ValidateTestCase extends TestCase
     {
         if (! $this->asserts->exists($code)) {
             $this->fail("Did not receive actual status for code '$code', it may not exists");
-            throw new \LogicException("Code $code did not exists");
         }
         return $this->asserts->get($code);
     }

--- a/tests/CfdiUtilsTests/XmlResolver/XmlResolverPropertyTraitTest.php
+++ b/tests/CfdiUtilsTests/XmlResolver/XmlResolverPropertyTraitTest.php
@@ -12,7 +12,7 @@ class XmlResolverPropertyTraitTest extends TestCase
     /** @var XmlResolverPropertyInterface */
     private $specimen;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->specimen = new class() implements XmlResolverPropertyInterface {

--- a/tests/CfdiUtilsTests/XmlResolver/XmlResolverPropertyTraitTest.php
+++ b/tests/CfdiUtilsTests/XmlResolver/XmlResolverPropertyTraitTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\XmlResolver\XmlResolverPropertyInterface;
 use CfdiUtils\XmlResolver\XmlResolverPropertyTrait;
 use CfdiUtilsTests\TestCase;
 
-class XmlResolverPropertyTraitTest extends TestCase
+final class XmlResolverPropertyTraitTest extends TestCase
 {
     /** @var XmlResolverPropertyInterface */
     private $specimen;

--- a/tests/CfdiUtilsTests/XmlResolver/XmlResolverTest.php
+++ b/tests/CfdiUtilsTests/XmlResolver/XmlResolverTest.php
@@ -7,7 +7,7 @@ use CfdiUtils\XmlResolver\XmlResolver;
 use CfdiUtilsTests\TestCase;
 use XmlResourceRetriever\Downloader\DownloaderInterface;
 
-class XmlResolverTest extends TestCase
+final class XmlResolverTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/CfdiUtilsTests/XmlResolver/XmlResolverTest.php
+++ b/tests/CfdiUtilsTests/XmlResolver/XmlResolverTest.php
@@ -80,7 +80,7 @@ class XmlResolverTest extends TestCase
         $resolver->resolve('http://example.org/example.xml');
     }
 
-    public function providerObtainTypeFromUrl()
+    public function providerObtainTypeFromUrl(): array
     {
         return [
             'xsd' => ['http://example.com/resource.xsd', XmlResolver::TYPE_XSD],
@@ -93,11 +93,11 @@ class XmlResolverTest extends TestCase
     }
 
     /**
-     * @dataProvider providerObtainTypeFromUrl
      * @param string $url
      * @param string $expectedType
+     * @dataProvider providerObtainTypeFromUrl
      */
-    public function testObtainTypeFromUrl($url, $expectedType)
+    public function testObtainTypeFromUrl(string $url, string $expectedType)
     {
         $resolver = new XmlResolver();
         $this->assertEquals($expectedType, $resolver->obtainTypeFromUrl($url));


### PR DESCRIPTION
Improvements:

- Include validation web service version 1.3 new response `ValidacionEFOS` as `StatusResponse::getValidationEfos() string` and `StatusResponse::isEfosListed() bool`.
- Update `ConsultaCFDIServiceSAT.svc.xml`. It is unused, but exists for compatibility.

General:

- Upgrade to PHPUnit 9.5 and upgrade test suite.
- Test classes are declared as final.
- Remove support for PHP 7.0, PHP 7.1 and PHP 7.2.
- Compatilize with PHP 8.0 / OpenSSL:
    - openssl functions does not return resources but objects.
    - On deprecated functions run only if PHP version is lower than 8.0 and put annotations for `phpcs`.

Bugfixes:

- Validation `SELLO04` fails when there are special caracters like `é` and `LC_CTYPE` is not setup.
- Fix `COMPIMPUESTOSC01` description typo.

There are some soft backwards incompatibility changes:

- Method __construct() of class CfdiUtils\Validate\Cfdi33\Standard\FechaComprobante became final
- Method __construct() of class CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago became final
- The return type of CfdiUtils\Validate\Cfdi33\RecepcionPagos\Pago#getValidators() changed from no type to array
- The parameter $decimals of CfdiUtils\Utils\Format::number() changed from no type to a non-contravariant int
- The parameter $content of CfdiUtils\Cleaner\Cleaner::staticClean() changed from no type to a non-contravariant string.

Development environment:

- AppVeyor: Only run PHPUnit
- Travis-CI: On PHP != 7.4 only run PHPUnit
- Travis-CI: On PHP == 7.4 run all the build commands
- PHPStan: Upgrade to version 0.12, downgrade level to 5.
