### PR TITLE
sumar impuestos locales

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,12 @@
 The following changes apply only to development and has been applied to main branch.
 
 
+## Version 2.17.0 2021-12-10
+
+The helper object `SumasConceptosWriter` also writes the sum of *impuestos locales* when they are present.
+Thanks, @ccelli33 and @luffinando for your help.
+
+
 ## Version 2.16.1 2021-12-08
 
 Fix bug when create expression to query for the SAT status and the RFC (*emisor* or *receptor*) contains

--- a/docs/crear/crear-cfdi.md
+++ b/docs/crear/crear-cfdi.md
@@ -25,7 +25,9 @@ Esta clase es una especie de pegamento de todas las pequeñas utilerías y estru
 - `buildSumasConceptos(int $precision = 2): SumasConceptos`: Genera un objeto de tipo `SumasConceptos` según los datos de los `Conceptos`.
 
 - `addSumasConceptos(SumasConceptos $sumasConceptos = null, int $precision = 2)`: Establece los valores de `$sumasConceptos`
-   en el comprobante, si no se pasó el objeto entonces lo fabrica con `buildSumasConceptos()`.
+   en el comprobante, si no se pasó el objeto entonces lo fabrica con `buildSumasConceptos()`. Las sumas en cuestión son
+   los valores del comprobante `SubTotal`, `Total` y `Descuento`, nodo de impuestos del comprobante, y también
+   los totales `TotaldeRetenciones` y `TotaldeTraslados` del complemento de impuestos locales.
 
 - `addSello(string $key, string $passPhrase = '')`: Realiza el procedimiento de firma con la llave primaria y
    almacena el valor de dicha llave en base64 en el atributo `Sello`.

--- a/src/CfdiUtils/Elements/Cfdi33/Helpers/SumasConceptosWriter.php
+++ b/src/CfdiUtils/Elements/Cfdi33/Helpers/SumasConceptosWriter.php
@@ -33,6 +33,7 @@ class SumasConceptosWriter
     {
         $this->putComprobanteSumas();
         $this->putImpuestosNode();
+        $this->putComplementoImpuestoLocalSumas();
     }
 
     private function putComprobanteSumas()
@@ -71,6 +72,25 @@ class SumasConceptosWriter
                 ...$this->getImpuestosContents($this->sumas->getRetenciones())
             );
         }
+    }
+
+    private function putComplementoImpuestoLocalSumas()
+    {
+        // search for implocal node
+        $impLocal = $this->comprobante->searchNode('cfdi:Complemento', 'implocal:ImpuestosLocales');
+        if (! $impLocal) {
+            return;
+        }
+        if (! $this->sumas->hasLocalesTraslados() && ! $this->sumas->hasLocalesRetenciones()) {
+            $complemento = $this->comprobante->getComplemento();
+            $complemento->children()->remove($impLocal);
+            if (0 === $complemento->count()) {
+                $this->comprobante->children()->remove($complemento);
+            }
+            return;
+        }
+        $impLocal->attributes()->set('TotaldeRetenciones', $this->format($this->sumas->getLocalesImpuestosRetenidos()));
+        $impLocal->attributes()->set('TotaldeTraslados', $this->format($this->sumas->getLocalesImpuestosTrasladados()));
     }
 
     private function getImpuestosContents(array $impuestos): array


### PR DESCRIPTION
- Se agrega función helper para la suma automática de los atributos requeridos en el complemento `implocal`: `TotaldeRetenciones` y `TotaldeTraslados`.