### PR TITLE
added mising Domicilio helper methods

### DIFF
--- a/src/CfdiUtils/Elements/CartaPorte10/Notificado.php
+++ b/src/CfdiUtils/Elements/CartaPorte10/Notificado.php
@@ -10,4 +10,18 @@ class Notificado extends AbstractElement
     {
         return 'cartaporte:Notificado';
     }
+
+    public function getDomicilio(): Domicilio
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->helperGetOrAdd(new Domicilio());
+    }
+
+    public function addDomicilio(array $attributes = []): Domicilio
+    {
+        $domicilio = $this->getDomicilio();
+        $domicilio->addAttributes($attributes);
+
+        return $domicilio;
+    }
 }

--- a/tests/CfdiUtilsTests/Elements/CartaPorte10/NotificadoTest.php
+++ b/tests/CfdiUtilsTests/Elements/CartaPorte10/NotificadoTest.php
@@ -2,13 +2,14 @@
 
 namespace CfdiUtilsTests\Elements\CartaPorte10;
 
+use CfdiUtils\Elements\CartaPorte10\Domicilio;
 use CfdiUtils\Elements\CartaPorte10\Notificado;
-use PHPUnit\Framework\TestCase;
+use CfdiUtilsTests\Elements\ElementTestCase;
 
 /**
  * @covers \CfdiUtils\Elements\CartaPorte10\Notificado
  */
-final class NotificadoTest extends TestCase
+final class NotificadoTest extends ElementTestCase
 {
     /** @var Notificado */
     public $element;
@@ -22,5 +23,10 @@ final class NotificadoTest extends TestCase
     public function testConstructedObject()
     {
         $this->assertSame('cartaporte:Notificado', $this->element->getElementName());
+    }
+
+    public function testDomicilio()
+    {
+        $this->assertElementHasChildSingle($this->element, Domicilio::class);
     }
 }


### PR DESCRIPTION
Se agregó el helper `Domicilio` faltante para la clase `Notificado` como lo muestra el xsd: 
![image](https://user-images.githubusercontent.com/23373649/147369005-c96fe01e-e3aa-45de-91b3-f45eeca3628a.png)
