### PR TITLE
Added missing new Regimen 626

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@
 The following changes apply only to development and has been applied to main branch.
 
 - Removed duplicated assert in Comprobante #84.
+- Added new regimen 626 in validator for EmisorRegimenFiscal class.
 
 
 ## Version 2.19.0 2022-01-17

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/EmisorRegimenFiscal.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/EmisorRegimenFiscal.php
@@ -30,7 +30,7 @@ class EmisorRegimenFiscal extends AbstractDiscoverableVersion33
             ];
         } elseif (13 === $length) {
             $validCodes = [
-                '605', '606', '608', '611', '612', '614', '616', '621', '629', '630', '615', '610', '622',
+                '605', '606', '608', '611', '612', '614', '616', '621', '629', '630', '615', '610', '622', '626',
             ];
         } else {
             $validCodes = [];

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/EmisorRegimenFiscal.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/EmisorRegimenFiscal.php
@@ -26,7 +26,7 @@ class EmisorRegimenFiscal extends AbstractDiscoverableVersion33
         $length = mb_strlen($emisorRfc);
         if (12 === $length) {
             $validCodes = [
-                '601', '603', '609', '620', '623', '624', '628', '607', '610', '622',
+                '601', '603', '609', '620', '623', '624', '628', '607', '610', '622', '626',
             ];
         } elseif (13 === $length) {
             $validCodes = [

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
@@ -30,7 +30,7 @@ final class EmisorRegimenFiscalTest extends Validate33TestCase
             ['AAA010101AAA', '622'],
             ['AAA010101AAA', '623'],
             ['AAA010101AAA', '624'],
-            ['AAAA010101AAA', '626'],
+            ['AAAA010101AA', '626'],
             ['AAA010101AAA', '628'],
             ['AAA010101AAA', '607'],
             ['ÑAA010101AAA', '601'], // with Ñ

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
@@ -46,6 +46,7 @@ final class EmisorRegimenFiscalTest extends Validate33TestCase
             ['AAAA010101AAA', '622'],
             ['AAAA010101AAA', '629'],
             ['AAAA010101AAA', '630'],
+            ['AAAA010101AAA', '626'], // regimen RESICO
             ['AAAA010101AAA', '615'],
             ['ÑAAA010101AAA', '605'], // with Ñ
             ['AAA010000AAA', '601'], // RFC inválido, regimen válido persona moral

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/EmisorRegimenFiscalTest.php
@@ -30,6 +30,7 @@ final class EmisorRegimenFiscalTest extends Validate33TestCase
             ['AAA010101AAA', '622'],
             ['AAA010101AAA', '623'],
             ['AAA010101AAA', '624'],
+            ['AAAA010101AAA', '626'],
             ['AAA010101AAA', '628'],
             ['AAA010101AAA', '607'],
             ['ÑAA010101AAA', '601'], // with Ñ


### PR DESCRIPTION
- Added new Regimen 626 in class `\CfdiUtils\Validate\Cfdi33\Standard\EmisorRegimenFiscal`. For avoid falling validation when using this regimen.