### PR TITLE
Add PHP 8.1 minimal compatibility.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,4 +27,3 @@
 /phpcs.xml.dist             export-ignore
 /phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         operating-systems: [ "ubuntu-latest", "windows-latest" ]
-        php-versions: [ '7.3', '7.4', '8.0' ]
+        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install libsaxonb-java on nektos/act
+        if: matrix.operating-systems == 'ubuntu-latest' && github.actor == 'nektos/act'
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq default-jre
+
       - name: Install libsaxonb-java on linux
         if: matrix.operating-systems == 'ubuntu-latest'
         run: sudo apt-get install -y -qq libsaxonb-java
@@ -96,6 +102,12 @@ jobs:
           tools: composer:v2, cs2pr
         env:
           fail-fast: true
+
+      - name: Install libsaxonb-java on nektos/act
+        if: matrix.operating-systems == 'ubuntu-latest' && github.actor == 'nektos/act'
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq default-jre
 
       - name: Install libsaxonb-java
         run: sudo apt-get install -y -qq libsaxonb-java

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,13 @@ Before you can run these, be sure to `composer install` or `composer update`.
 ```shell
 composer dev:build
 ```
+
+## Running GitHub Actions locally
+
+You can use [`act`](https://github.com/nektos/act) to run your GitHub Actions locally.
+As documented in [`actions/setup-php-action`](https://github.com/marketplace/actions/setup-php-action#local-testing-setup)
+you will need to execute the command as:
+
+```shell
+act -P ubuntu-latest=shivammathur/node:latest
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library provides helper objects to work with Mexican CFDI (Comprobante Fisc
 También te esperamos en el canal [#phpcfdi de discord](https://discord.gg/aFGYXvX).
 
 The documentation related to this library and its API is on [Read the docs][documentation].
-It is written in **spanish language** since is the language of the intented audience.
+It is written in **spanish language** since is the language of the intended audience.
 
 **Nota: Este proyecto será migrado a `phpcfdi/cfdiutils`, aún no tenemos fecha planeada**
 
@@ -38,9 +38,9 @@ CFDI y herramientas del SAT. Y próximamente el lugar donde publicaremos la vers
     - Extract information from CER files or `Certificado` attribute.
     - Calculate `Comprobante` sums based on the list of `Conceptos`.
     - Retrieve the CFDI version information.
-- Keep a local copy of the tree of XSD and XSLT file dependences from SAT.
+- Keep a local copy of the tree of XSD and XSLT file dependencies from SAT.
 - Keep a local copy of certificates to avoid downloads them each time.
-- Check the SAT WebService to get the status of a CFDI (*Estado*, *EsCancelable* y *EstatusCancelacion*) without WSDL.
+- Check the SAT WebService to get the status of a CFDI (*Estado*, *EsCancelable* and *EstatusCancelacion*) without WSDL.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -69,14 +69,15 @@ This library is compatible with **PHP 7.3 and above**. Please, try to use the la
 The intended support is to be aligned with oldest *Active support* PHP Branch.
 See <https://www.php.net/supported-versions.php> for more details.
 
-| CfdiUtils | PHP Supported versions   | Since      |
-| --------- | ------------------------ | ---------- |
-| 1.0       | 7.0, 7.1                 | 2017-09-27 |
-| 2.0       | 7.0, 7.1                 | 2018-01-01 |
-| 2.0.1     | 7.0, 7.1, 7.2            | 2018-01-03 |
-| 2.8.1     | 7.0, 7.1, 7.2, 7.3       | 2019-03-05 |
-| 2.12.7    | 7.0, 7.1, 7.2, 7.3, 7.4  | 2019-12-04 |
-| 2.15.0    | 7.3, 7.4, 8.0            | 2021-03-17 |
+| CfdiUtils | PHP Supported versions  | Since      |
+|-----------|-------------------------|------------|
+| 1.0       | 7.0, 7.1                | 2017-09-27 |
+| 2.0       | 7.0, 7.1                | 2018-01-01 |
+| 2.0.1     | 7.0, 7.1, 7.2           | 2018-01-03 |
+| 2.8.1     | 7.0, 7.1, 7.2, 7.3      | 2019-03-05 |
+| 2.12.7    | 7.0, 7.1, 7.2, 7.3, 7.4 | 2019-12-04 |
+| 2.15.0    | 7.3, 7.4, 8.0           | 2021-03-17 |
+| 2.20.1    | 7.3, 7.4, 8.0, 8.1      | 2022-03-08 |
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-json": "*",
         "symfony/process": "^3.4|^4.2|^5.0|^6.0",
         "eclipxe/xmlresourceretriever": "^1.3.0",
-        "eclipxe/xmlschemavalidator": "^2.0.2"
+        "eclipxe/xmlschemavalidator": "^3.0.2"
     },
     "suggest": {
         "genkgo/xsl": "Allows usage of Genkgo/Xsl transformations"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-soap": "*",
         "ext-iconv": "*",
         "ext-json": "*",
-        "symfony/process": "^3.4|^4.2|^5.0",
+        "symfony/process": "^3.4|^4.2|^5.0|^6.0",
         "eclipxe/xmlresourceretriever": "^1.3.0",
         "eclipxe/xmlschemavalidator": "^2.0.2"
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,23 @@
 - Remove classes `CfdiUtils\Elements\Cfdi33\Helpers\SumasConceptosWriter` and `CfdiUtils\Elements\Cfdi40\Helpers\SumasConceptosWriter`.
 
 
+## Version 2.20.1 2022-03-08
+
+Add PHP 8.1 minimal compatibility.
+
+Skip tests on `GenkgoXslBuilderTest` because the library `genkgo/xsl` is not compatible with PHP 8.1. 
+
+Skip tests `WebServiceConsumingTest::testSoapClientHasSettings` because cannot access `SoapClient` private properties.
+
+Add dependence on `symfony/process` to include 6.0. This allows to install the library on PHP 8.1.
+
+Upgrade `eclipxe/xmlschemavalidator` from version 2.x to version 3.x (fully PHP 8.1 compatible).
+
+Add `#[\ReturnTypeWillChange]` or fix return types on implemented classes like
+`IteratorAggregate::getIterator(): Traversable`.
+
+Add information about how tu run locally GitHub Actions using  `nektos/act` tool.
+
 ## Version 2.20.0 2022-02-22
 
 Add `CfdiUtils\Elements\Pagos20` *Elements* to work with "Complemento para recepción de Pagos 2.0".

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 Add PHP 8.1 minimal compatibility.
 
-Skip tests on `GenkgoXslBuilderTest` because the library `genkgo/xsl` is not compatible with PHP 8.1. 
+Skip tests on `GenkgoXslBuilderTest` because the library `genkgo/xsl` is not compatible with PHP 8.1.
 
 Skip tests `WebServiceConsumingTest::testSoapClientHasSettings` because cannot access `SoapClient` private properties.
 
@@ -48,10 +48,12 @@ Add `#[\ReturnTypeWillChange]` or fix return types on implemented classes like
 
 Add information about how tu run locally GitHub Actions using  `nektos/act` tool.
 
+
 ## Version 2.20.0 2022-02-22
 
 Add `CfdiUtils\Elements\Pagos20` *Elements* to work with "Complemento para recepción de Pagos 2.0".
 Thanks @EmmanuelJCS.
+
 
 ## Version 2.19.1 2022-02-09
 
@@ -111,6 +113,7 @@ Other changes:
 
 - Update license year, happy new year.
 - Update PHPUnit config file.
+
 
 ## Version 2.18.3 2022-01-15
 

--- a/src/CfdiUtils/Nodes/Attributes.php
+++ b/src/CfdiUtils/Nodes/Attributes.php
@@ -3,10 +3,11 @@
 namespace CfdiUtils\Nodes;
 
 use CfdiUtils\Utils\Xml;
+use Traversable;
 
 class Attributes implements \Countable, \IteratorAggregate, \ArrayAccess
 {
-    /** @var string[] */
+    /** @var array<string, string> */
     private $attributes = [];
 
     public function __construct(array $attributes = [])
@@ -91,33 +92,38 @@ class Attributes implements \Countable, \IteratorAggregate, \ArrayAccess
         throw new \InvalidArgumentException(sprintf('Cannot convert value of attribute %s to string', $key));
     }
 
-    public function getIterator()
+    /** @return Traversable<string, string> */
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->attributes);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->exists((string) $offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get((string) $offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $offset = strval($offset);
         $this->set($offset, $this->castValueToString($offset, $value));
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->remove((string) $offset);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->attributes);
     }

--- a/src/CfdiUtils/Nodes/Node.php
+++ b/src/CfdiUtils/Nodes/Node.php
@@ -3,6 +3,7 @@
 namespace CfdiUtils\Nodes;
 
 use CfdiUtils\Utils\Xml;
+use Traversable;
 
 class Node implements NodeInterface
 {
@@ -111,21 +112,25 @@ class Node implements NodeInterface
      * Array access implementation as attribute helpers
      */
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->attributes[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->attributes[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->attributes[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->attributes[$offset]);
@@ -135,18 +140,13 @@ class Node implements NodeInterface
      * other interfaces
      */
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return $this->children->count();
     }
 
-    /**
-     * @return \ArrayIterator|\Traversable
-     */
-    public function getIterator()
+    /** @return Traversable<NodeInterface> */
+    public function getIterator(): Traversable
     {
         return $this->children->getIterator();
     }

--- a/src/CfdiUtils/Nodes/Nodes.php
+++ b/src/CfdiUtils/Nodes/Nodes.php
@@ -2,6 +2,8 @@
 
 namespace CfdiUtils\Nodes;
 
+use Traversable;
+
 class Nodes implements \Countable, \IteratorAggregate
 {
     /** @var NodeInterface[] */
@@ -145,18 +147,13 @@ class Nodes implements \Countable, \IteratorAggregate
         return $this;
     }
 
-    /**
-     * @return \ArrayIterator|\Traversable
-     */
-    public function getIterator()
+    /** @return Traversable<NodeInterface> */
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->nodes);
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return count($this->nodes);
     }

--- a/src/CfdiUtils/QuickReader/QuickReader.php
+++ b/src/CfdiUtils/QuickReader/QuickReader.php
@@ -125,11 +125,13 @@ class QuickReader extends \stdClass implements \ArrayAccess
         return $this->getAttributeByName((string) $name) ?? '';
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new \LogicException('Cannot change attributes');
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new \LogicException('Cannot change attributes');

--- a/src/CfdiUtils/Utils/SchemaLocations.php
+++ b/src/CfdiUtils/Utils/SchemaLocations.php
@@ -136,11 +136,9 @@ class SchemaLocations implements Countable, IteratorAggregate
     }
 
     /** @return Traversable<string, string> */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
-        /** @var Traversable<string, string> $traversable */
-        $traversable = new ArrayIterator($this->pairs);
-        return $traversable;
+        return new ArrayIterator($this->pairs);
     }
 
     public function count(): int

--- a/src/CfdiUtils/Validate/Asserts.php
+++ b/src/CfdiUtils/Validate/Asserts.php
@@ -2,9 +2,11 @@
 
 namespace CfdiUtils\Validate;
 
+use Traversable;
+
 class Asserts implements \Countable, \IteratorAggregate
 {
-    /** @var Assert[] */
+    /** @var array<string, Assert> */
     private $asserts = [];
 
     /** @var bool */
@@ -199,18 +201,13 @@ class Asserts implements \Countable, \IteratorAggregate
         $this->mustStop($asserts->mustStop());
     }
 
-    /**
-     * @return \ArrayIterator|\Traversable
-     */
-    public function getIterator()
+    /** @return Traversable<string, Assert> */
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->asserts);
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return count($this->asserts);
     }

--- a/src/CfdiUtils/Validate/MultiValidator.php
+++ b/src/CfdiUtils/Validate/MultiValidator.php
@@ -4,6 +4,7 @@ namespace CfdiUtils\Validate;
 
 use CfdiUtils\Nodes\NodeInterface;
 use CfdiUtils\Validate\Contracts\ValidatorInterface;
+use Traversable;
 
 class MultiValidator implements ValidatorInterface, \Countable, \IteratorAggregate
 {
@@ -90,18 +91,13 @@ class MultiValidator implements ValidatorInterface, \Countable, \IteratorAggrega
         $this->validators = [];
     }
 
-    /**
-     * @return \ArrayIterator|\Traversable
-     */
-    public function getIterator()
+    /** @return Traversable<ValidatorInterface> */
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->validators);
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return count($this->validators);
     }

--- a/src/CfdiUtils/Validate/Xml/XmlFollowSchema.php
+++ b/src/CfdiUtils/Validate/Xml/XmlFollowSchema.php
@@ -12,9 +12,9 @@ use CfdiUtils\Validate\Status;
 use CfdiUtils\Validate\Traits\XmlStringPropertyTrait;
 use CfdiUtils\XmlResolver\XmlResolverPropertyInterface;
 use CfdiUtils\XmlResolver\XmlResolverPropertyTrait;
-use XmlSchemaValidator\Schema;
-use XmlSchemaValidator\Schemas;
-use XmlSchemaValidator\SchemaValidator;
+use Eclipxe\XmlSchemaValidator\Schema;
+use Eclipxe\XmlSchemaValidator\Schemas;
+use Eclipxe\XmlSchemaValidator\SchemaValidator;
 
 /**
  * XmlFollowSchema
@@ -54,7 +54,7 @@ class XmlFollowSchema implements
         }
 
         // create the schema validator object
-        $schemaValidator = new SchemaValidator($content);
+        $schemaValidator = SchemaValidator::createFromString($content);
 
         // validate using resolver->retriever or using the simple method
         try {

--- a/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
@@ -5,6 +5,7 @@ namespace CfdiUtilsTests\CadenaOrigen;
 use CfdiUtils\CadenaOrigen\GenkgoXslBuilder;
 use CfdiUtils\CadenaOrigen\XsltBuilderInterface;
 
+/** @requires PHP < 8.1 */
 final class GenkgoXslBuilderTest extends GenericBuilderTestCase
 {
     protected function setUp(): void

--- a/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
+++ b/tests/CfdiUtilsTests/ConsultaCfdiSat/WebServiceConsumingTest.php
@@ -57,6 +57,7 @@ final class WebServiceConsumingTest extends TestCase
         $this->assertNotSame($soapClient, $this->tolerantSoapClient($ws));
     }
 
+    /** @requires PHP < 8.1 */
     public function testSoapClientHasSettings()
     {
         $config = new Config(60, false, '');


### PR DESCRIPTION
Skip tests on `GenkgoXslBuilderTest` because the library `genkgo/xsl` is not compatible with PHP 8.1. 

Skip tests `WebServiceConsumingTest::testSoapClientHasSettings` because cannot access `SoapClient` private properties.

Add dependence on `symfony/process` to include 6.0. This allows to install the library on PHP 8.1.

Upgrade `eclipxe/xmlschemavalidator` from version 2.x to version 3.x (fully PHP 8.1 compatible).

Add `#[\ReturnTypeWillChange]` or fix return types on implemented classes like
`IteratorAggregate::getIterator(): Traversable`.

Add information about how tu run locally GitHub Actions using  `nektos/act` tool.