### PR TITLE
Fix build 2022-03-18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,15 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install libsaxonb-java on nektos/act
-        if: matrix.operating-systems == 'ubuntu-latest' && github.actor == 'nektos/act'
-        run: |
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -qq default-jre
-
       - name: Install libsaxonb-java on linux
         if: matrix.operating-systems == 'ubuntu-latest'
-        run: sudo apt-get install -y -qq libsaxonb-java
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq default-jre libsaxonb-java
 
       - name: Install saxonhe on windows
         if: matrix.operating-systems == 'windows-latest'
@@ -103,14 +99,11 @@ jobs:
         env:
           fail-fast: true
 
-      - name: Install libsaxonb-java on nektos/act
-        if: matrix.operating-systems == 'ubuntu-latest' && github.actor == 'nektos/act'
+      - name: Install libsaxonb-java on linux
+        if: matrix.operating-systems == 'ubuntu-latest'
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install -y -qq default-jre
-
-      - name: Install libsaxonb-java
-        run: sudo apt-get install -y -qq libsaxonb-java
+          sudo apt-get install -y -qq default-jre libsaxonb-java
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,8 +143,10 @@ jobs:
 
       - name: Upload code coverage to scrutinizer
         uses: sudo-bot/action-scrutinizer@latest
-        with:
-          cli-args: "--format=php-clover build/coverage-clover.xml"
+        run:
+          mkdir -p build/scrutinizer
+          composer require scrutinizer/ocular --working-dir build/scrutinizer --no-progress
+          build/scrutinizer/vendor/bin/ocular code-coverage:upload --no-interaction --format=php-clover build/coverage-clover.xml
 
       # see https://github.com/marketplace/actions/mkdocs-action
       - name: Run mkdocs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
         run: vendor/bin/phpstan analyse --no-progress --verbose src/ tests/
 
       - name: Upload code coverage to scrutinizer
-        run:
+        run: |
           mkdir -p build/scrutinizer
           composer require scrutinizer/ocular --working-dir build/scrutinizer --no-progress
           build/scrutinizer/vendor/bin/ocular code-coverage:upload --no-interaction --format=php-clover build/coverage-clover.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install libsaxonb-java on linux
         if: matrix.operating-systems == 'ubuntu-latest'
@@ -86,7 +86,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
@@ -144,8 +146,8 @@ jobs:
       - name: Upload code coverage to scrutinizer
         run: |
           mkdir -p build/scrutinizer
-          composer require scrutinizer/ocular --working-dir build/scrutinizer --no-progress
-          build/scrutinizer/vendor/bin/ocular code-coverage:upload --no-interaction --format=php-clover build/coverage-clover.xml
+          composer require scrutinizer/ocular:dev-master --working-dir=build/scrutinizer --no-progress
+          php build/scrutinizer/vendor/bin/ocular code-coverage:upload -vvv --no-interaction --format=php-clover build/coverage-clover.xml
 
       # see https://github.com/marketplace/actions/mkdocs-action
       - name: Run mkdocs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,6 @@ jobs:
         run: vendor/bin/phpstan analyse --no-progress --verbose src/ tests/
 
       - name: Upload code coverage to scrutinizer
-        uses: sudo-bot/action-scrutinizer@latest
         run:
           mkdir -p build/scrutinizer
           composer require scrutinizer/ocular --working-dir build/scrutinizer --no-progress

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ When you do begin working on your feature, here are some guidelines to consider:
 
 ## Check the code style
 
-If you are having issues with coding standars then run:
+If you are having issues with coding standards then run:
 
 ```shell
 composer dev:check-style

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,9 @@
 
 ## Unreleased 2022-03-18
 
+Fix build since GitHub Action `sudo-bot/action-scrutinizer` is failing.
+Use `scrutinizer/ocular` package instead.
+
 CI: Always run `apt-get update` before `apt-get install`.
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,8 @@
 Fix build since GitHub Action `sudo-bot/action-scrutinizer` is failing.
 Use `scrutinizer/ocular` package instead.
 
+Test: When creating a pago, use `addSumasConceptos` to populate `SubTotal` and `Total`.
+
 CI: Always run `apt-get update` before `apt-get install`.
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,11 @@
 - Remove classes `CfdiUtils\Elements\Cfdi33\Helpers\SumasConceptosWriter` and `CfdiUtils\Elements\Cfdi40\Helpers\SumasConceptosWriter`.
 
 
+## Unreleased 2022-03-18
+
+CI: Always run `apt-get update` before `apt-get install`.
+
+
 ## Version 2.20.1 2022-03-08
 
 Add PHP 8.1 minimal compatibility.

--- a/tests/CfdiUtilsTests/CreateComprobantePagos33CaseTest.php
+++ b/tests/CfdiUtilsTests/CreateComprobantePagos33CaseTest.php
@@ -24,8 +24,6 @@ final class CreateComprobantePagos33CaseTest extends TestCase
             'TipoDeComprobante' => 'P', // pago
             'LugarExpedicion' => '52000',
             'Moneda' => 'XXX',
-            'Total' => '0',
-            'SubTotal' => '0',
         ]);
         $creator->putCertificado($certificado, false);
 
@@ -82,6 +80,9 @@ final class CreateComprobantePagos33CaseTest extends TestCase
 
         // add the "complemento de pagos" ($complementoPagos) to the $comprobante
         $comprobante->addComplemento($complementoPagos);
+
+        // use this method (with 0 decimals) to add attributes
+        $creator->addSumasConceptos(null, 0);
 
         // add sello and validate to assert that the specimen does not have any errors
         $creator->addSello('file://' . $keyfile, '');


### PR DESCRIPTION
Fix build since GitHub Action `sudo-bot/action-scrutinizer` is failing.
Use `scrutinizer/ocular` package instead.

Test: When creating a pago, use `addSumasConceptos` to populate `SubTotal` and `Total`.

CI: Always run `apt-get update` before `apt-get install`.
