### PR TITLE
Genkgo/Xsl version 1.1.0 (Version 2.20.2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "genkgo/xsl": "Allows usage of Genkgo/Xsl transformations"
     },
     "require-dev": {
-        "genkgo/xsl": "dev-master",
+        "genkgo/xsl": "^1.0.8|^1.1.0",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6",
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpstan/phpstan": "^0.12"
+        "phpstan/phpstan": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,15 @@
 - Remove classes `CfdiUtils\Elements\Cfdi33\Helpers\SumasConceptosWriter` and `CfdiUtils\Elements\Cfdi40\Helpers\SumasConceptosWriter`.
 
 
-## Unreleased 2022-03-18
+## Version 2.20.2 2022-04-05
+
+Allow installing Genkgo/Xsl version 1.1.0; used for PHP >= 7.4.
+
+Test: Fix test that was overriding `retenciones/sample-before-tfd.xml` file.
+
+Include the following unreleased changes
+
+### 2022-03-18
 
 Fix build since GitHub Action `sudo-bot/action-scrutinizer` is failing.
 Use `scrutinizer/ocular` package instead.

--- a/src/CfdiUtils/Utils/Xml.php
+++ b/src/CfdiUtils/Utils/Xml.php
@@ -53,7 +53,7 @@ class Xml
         // this error silenced call is intentional, no need to alter libxml_use_internal_errors
         if (false === @$document->loadXML($content)) {
             throw new \UnexpectedValueException(
-                trim('Cannot create a DOM Document from xml string' . PHP_EOL . static::castLibXmlLastErrorAsString())
+                trim('Cannot create a DOM Document from xml string' . PHP_EOL . self::castLibXmlLastErrorAsString())
             );
         }
         return $document;
@@ -106,7 +106,7 @@ class Xml
      */
     public static function createElement(DOMDocument $document, string $name, string $content = ''): DOMElement
     {
-        return static::createDOMElement(
+        return self::createDOMElement(
             function () use ($document, $name) {
                 return $document->createElement($name);
             },
@@ -131,7 +131,7 @@ class Xml
         string $name,
         string $content = ''
     ): DOMElement {
-        return static::createDOMElement(
+        return self::createDOMElement(
             function () use ($document, $namespaceURI, $name) {
                 return $document->createElementNS($namespaceURI, $name);
             },

--- a/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
@@ -4,13 +4,13 @@ namespace CfdiUtilsTests\CadenaOrigen;
 
 use CfdiUtils\CadenaOrigen\GenkgoXslBuilder;
 use CfdiUtils\CadenaOrigen\XsltBuilderInterface;
+use Genkgo\Xsl\XsltProcessor;
 
-/** @requires PHP < 8.1 */
 final class GenkgoXslBuilderTest extends GenericBuilderTestCase
 {
     protected function setUp(): void
     {
-        if (! class_exists(\Genkgo\Xsl\XsltProcessor::class)) {
+        if (! class_exists(XsltProcessor::class)) {
             $this->markTestSkipped('Genkgo/Xsl is not installed');
         }
     }

--- a/tests/CfdiUtilsTests/Retenciones/RetencionesCreator10Test.php
+++ b/tests/CfdiUtilsTests/Retenciones/RetencionesCreator10Test.php
@@ -80,7 +80,6 @@ final class RetencionesCreator10Test extends TestCase
         $this->assertFalse($asserts->hasErrors());
 
         // check against known content
-        file_put_contents($this->utilAsset('retenciones/sample-before-tfd.xml'), $creator->asXml());
         $this->assertXmlStringEqualsXmlFile($this->utilAsset('retenciones/sample-before-tfd.xml'), $creator->asXml());
     }
 


### PR DESCRIPTION
Allow installing Genkgo/Xsl version 1.1.0; used for PHP >= 7.4.

Test: Fix test that was overriding `retenciones/sample-before-tfd.xml` file.