### PR TITLE
Fix SumasConceptos with Exentos (version 2.23.3)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,14 @@
 - Merge methods from `\CfdiUtils\Nodes\NodeHasValueInterface` into `\CfdiUtils\Nodes\NodeInterface`.
 - Remove deprecated constant `CfdiUtils\Retenciones\Retenciones::RET_NAMESPACE`.
 
+## Version 2.23.3 2022-08-11
+
+Fix CFDI 4.0, must include `Comprobante/Impuestos/Traslados/Traslado@TipoFactor=Exento` when exists at least one
+node `Comprobante/Conceptos/Concepto/Impuestos/Traslados/Traslado@TipoFactor=Exento`.
+The node must contain attribute `TipoFactor=Exento` and the rounded sum of the attributes `Base`
+grouped by attribute `Impuesto`.
+Thanks `BrodyAG` for noticing this issue, and `@yairtestas` for your guidance to find the solution.
+
 ## Version 2.23.2 2022-06-29
 
 Use `Symfony/Process` instead of `ShellExec`.

--- a/tests/CfdiUtilsTests/CreateComprobanteWithOnlyExentosCaseTest.php
+++ b/tests/CfdiUtilsTests/CreateComprobanteWithOnlyExentosCaseTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace CfdiUtilsTests;
+
+use CfdiUtils\CfdiCreator33;
+use CfdiUtils\CfdiCreator40;
+use CfdiUtils\Nodes\Node;
+use CfdiUtils\Nodes\XmlNodeUtils;
+
+final class CreateComprobanteWithOnlyExentosCaseTest extends TestCase
+{
+    public function testCreateCcomprobante33WithOnlyExentosWriteImpuestos(): void
+    {
+        $creator = new CfdiCreator33([]);
+
+        $comprobante = $creator->comprobante();
+        $comprobante->addConcepto([
+            'ClaveProdServ' => '01010101',
+            'NoIdentificacion' => 'FOO',
+            'Cantidad' => '1',
+            'ClaveUnidad' => 'E48',
+            'Descripcion' => 'HONORARIOS MEDICOS',
+            'ValorUnitario' => '617.000000',
+            'Importe' => '617.000000',
+            'Descuento' => '144.271240',
+            'ObjetoImp' => '02',
+        ])->addTraslado([
+            'Impuesto' => '002',
+            'TipoFactor' => 'Exento',
+        ]);
+
+        // test sumasConceptos
+
+        $precision = 2;
+        $sumasConceptos = $creator->buildSumasConceptos($precision);
+        $this->assertTrue($sumasConceptos->hasExentos());
+        $this->assertFalse($sumasConceptos->hasTraslados());
+        $this->assertFalse($sumasConceptos->hasRetenciones());
+
+        $expectedExentos = [
+            '002:Exento:' => [
+                'TipoFactor' => 'Exento',
+                'Impuesto' => '002',
+                'Base' => 0,
+            ],
+        ];
+
+        $this->assertEquals($expectedExentos, $sumasConceptos->getExentos());
+
+        // test cfdi:Impuestos XML does not exists
+
+        $creator->addSumasConceptos($sumasConceptos, $precision);
+
+        $this->assertNull($comprobante->searchNode('cfdi:Impuestos'));
+    }
+
+    public function testCreateCcomprobante40WithOnlyExentosWriteImpuestos(): void
+    {
+        $creator = new CfdiCreator40([]);
+
+        $comprobante = $creator->comprobante();
+        $comprobante->addConcepto([
+            'ClaveProdServ' => '01010101',
+            'NoIdentificacion' => 'FOO',
+            'Cantidad' => '1',
+            'ClaveUnidad' => 'E48',
+            'Descripcion' => 'HONORARIOS MEDICOS',
+            'ValorUnitario' => '617.000000',
+            'Importe' => '617.000000',
+            'Descuento' => '144.271240',
+            'ObjetoImp' => '02',
+        ])->addTraslado([
+            'Base' => '472.728760',
+            'Impuesto' => '002',
+            'TipoFactor' => 'Exento',
+        ]);
+
+        // test sumasConceptos
+
+        $precision = 2;
+        $sumasConceptos = $creator->buildSumasConceptos($precision);
+        $this->assertTrue($sumasConceptos->hasExentos());
+        $this->assertFalse($sumasConceptos->hasTraslados());
+        $this->assertFalse($sumasConceptos->hasRetenciones());
+
+        $expectedExentos = [
+            '002:Exento:' => [
+                'TipoFactor' => 'Exento',
+                'Impuesto' => '002',
+                'Base' => 472.72876,
+            ],
+        ];
+
+        $this->assertEquals($expectedExentos, $sumasConceptos->getExentos());
+
+        // test cfdi:Impuestos XML
+
+        $creator->addSumasConceptos($sumasConceptos, $precision);
+
+        $expectedImpuestosNode = new Node('cfdi:Impuestos', [], [
+            new Node('cfdi:Traslados', [], [
+                new Node('cfdi:Traslado', ['TipoFactor' => 'Exento', 'Impuesto' => '002', 'Base' => '472.73']),
+            ]),
+        ]);
+
+        $this->assertXmlStringEqualsXmlString(
+            XmlNodeUtils::nodeToXmlString($expectedImpuestosNode),
+            XmlNodeUtils::nodeToXmlString($comprobante->searchNode('cfdi:Impuestos'))
+        );
+    }
+}

--- a/tests/CfdiUtilsTests/SumasConceptos/SumasConceptosTest.php
+++ b/tests/CfdiUtilsTests/SumasConceptos/SumasConceptosTest.php
@@ -251,13 +251,15 @@ final class SumasConceptosTest extends TestCase
         $this->assertCount(0, $sumas->getTraslados());
 
         $this->assertTrue($sumas->hasExentos());
+
         $exentos001 = array_filter($sumas->getExentos(), function (array $values): bool {
-            return '001' === strval($values['Impuesto'] ?? '');
-        });
-        $exentos002 = array_filter($sumas->getExentos(), function (array $values): bool {
-            return '002' === strval($values['Impuesto'] ?? '');
+            return '001' === $values['Impuesto'];
         });
         $this->assertEqualsWithDelta(250.00, array_sum(array_column($exentos001, 'Base')), 0.001);
+
+        $exentos002 = array_filter($sumas->getExentos(), function (array $values): bool {
+            return '002' === $values['Impuesto'];
+        });
         $this->assertEqualsWithDelta(666.66, array_sum(array_column($exentos002, 'Base')), 0.001);
     }
 }


### PR DESCRIPTION
Fix CFDI 4.0, must include `Comprobante/Impuestos/Traslados/Traslado@TipoFactor=Exento` when exists at least one node `Comprobante/Conceptos/Concepto/Impuestos/Traslados/Traslado@TipoFactor=Exento`.
The node must contain attribute `TipoFactor=Exento` and the rounded sum of the attributes `Base` grouped by attribute `Impuesto`.
Thanks `BrodyAG` for noticing this issue, and @yairtestas for your guidance to find the solution.
