### PR TITLE
Version 2.23.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -42,7 +42,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -83,7 +83,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: soap, intl, xsl, fileinfo
           coverage: none
           tools: composer:v2, phpstan
@@ -108,7 +108,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -162,7 +162,7 @@ jobs:
     runs-on: "windows-latest"
     strategy:
       matrix:
-        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
+          extensions: soap, intl, xsl, fileinfo
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -124,6 +125,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
+          extensions: soap, intl, xsl, fileinfo
           coverage: xdebug
           tools: composer:v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,9 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
-        run: composer upgrade --no-interaction --no-progress --prefer-dist
+        run: |
+          composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
+          composer upgrade --no-interaction --no-progress --prefer-dist
       - name: PHPStan
         run: phpstan analyse --no-progress --verbose src/ tests/
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,7 +24,7 @@ return (new PhpCsFixer\Config())
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
         'self_accessor' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 2022 Carlos C Soto
+Copyright (c) 2016 - 2023 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-discord]: https://img.shields.io/discord/459860554090283019?logo=discord&style=flat-square
 [badge-release]: https://img.shields.io/github/release/eclipxe13/CfdiUtils?logo=git&style=flat-square
 [badge-license]: https://img.shields.io/github/license/eclipxe13/CfdiUtils?logo=open-source-initiative&style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/eclipxe13/CfdiUtils/build/master?logo=github-actions&style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/eclipxe13/CfdiUtils/build.yml?branch=master&logo=github-actions&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/eclipxe13/CfdiUtils/master?logo=scrutinizer-ci&style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/eclipxe13/CfdiUtils/master?logo=scrutinizer-ci&style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/eclipxe/CfdiUtils?logo=composer&style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "genkgo/xsl": "Allows usage of Genkgo/Xsl transformations"
     },
     "require-dev": {
-        "genkgo/xsl": "^1.0.8|^1.1.0",
+        "genkgo/xsl": "^1.0.8",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6",
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         {
             "name": "Carlos C Soto",
             "email": "eclipxe13@gmail.com",
-            "homepage": "http://eclipxe.com.mx/"
+            "homepage": "https://eclipxe.com.mx/"
         }
     ],
     "config": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,25 @@
 - Merge methods from `\CfdiUtils\Nodes\NodeHasValueInterface` into `\CfdiUtils\Nodes\NodeInterface`.
 - Remove deprecated constant `CfdiUtils\Retenciones\Retenciones::RET_NAMESPACE`.
 
+## Version 2.23.5 2023-05-25
+
+- Fix `SELLO04` false positives on CFDI 4.0.
+    - If name is empty then status is *error* since it is mandatory.
+    - If *Persona Moral* then status is *none* since it is not possible to compare names.
+    - If *Persona Física* then status is *ok* when name is **identical** to certificate name.
+- Improve `SUMAS07` explanation.
+- Fix PHPStan false positives.
+- Update license year.
+- Update `php-cs-fixer` configuration file.
+- Fix `genkgo/xsl` dependency version.
+- GitHub Workflow:
+    - Add PHP 8.2 to test matrix.
+    - Jobs run in PHP 8.2.
+    - Remove development tools before install project dependencies.
+- Fix build badge.
+- When testing using Genkgo, ignore deprecation errors.
+- Replace `utf8_decode` calls with `mb_convert_encoding`.
+
 ## Version 2.23.4 2022-12-07
 
 This is a maintenance release to fix the continuous integration workflow and append pending development changes.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 ## Version 2.23.4 2022-12-07
 
-This is a maintenance release fo fix the continuous integration workflow and append pending development changes.
+This is a maintenance release to fix the continuous integration workflow and append pending development changes.
 
 - Fix test  `CertificadoTest::testConstructWithValidExample()` to allow quoted slashes on name.
 - Add *phpdoc* to the method `Certificate::getCertificateName()`.
@@ -277,7 +277,7 @@ General:
 - Upgrade to PHPUnit 9.5 and upgrade test suite.
 - Test classes are declared as final.
 - Remove support for PHP 7.0, PHP 7.1 and PHP 7.2.
-- Compatibilize with PHP 8.0 / OpenSSL:
+- Grant compatibility with PHP 8.0 / OpenSSL:
     - openssl functions does not return resources but objects.
     - On deprecated functions run only if PHP version is lower than 8.0 and put annotations for `phpcs`.
 
@@ -791,7 +791,7 @@ This problem does not exist anymore (since 2019-10-24).
 - Add badges to `docs/index.md`
 
 
-## Version 2.6.0 2018-07-06 - bugfixes, quickreader & welcome readthedocs & mkdocs
+## Version 2.6.0 2018-07-06 - bugfixes, QuickReader & welcome ReadTheDocs & MkDocs
 
 - Create `QuickReader`, utility for easy navigate and extract information from a CFDI
 - Fix `Rfc` to don't throw an exception if checksum fails, SAT is not following its own standard
@@ -1010,7 +1010,7 @@ This problem does not exist anymore (since 2019-10-24).
   subject x500UniqueIdentifier field
 
 
-## Version 1.0.2 2017-09-28 - Thanks phpstan!
+## Version 1.0.2 2017-09-28 - Thanks PHPStan!
 
 - After using `phpstan/phpstan` change the execution plan on `CadenaOrigenLocations`.
   The function previous function `throwLibXmlErrorOrMessage(string $message)` always

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,7 +130,7 @@ y se encuentra amparada por la Licencia MIT (MIT). Consulte el archivo [LICENSE]
 [badge-discord]: https://img.shields.io/discord/459860554090283019?logo=discord&style=flat-square
 [badge-release]: https://img.shields.io/github/release/eclipxe13/CfdiUtils?logo=git&style=flat-square
 [badge-license]: https://img.shields.io/github/license/eclipxe13/CfdiUtils?logo=open-source-initiative&style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/eclipxe13/CfdiUtils/build/master?logo=github-actions&style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/eclipxe13/CfdiUtils/build.yml?branch=master&logo=github-actions&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/eclipxe13/CfdiUtils/master?logo=scrutinizer-ci&style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/eclipxe13/CfdiUtils/master?logo=scrutinizer-ci&style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/eclipxe/CfdiUtils?logo=composer&style=flat-square

--- a/src/CfdiUtils/Nodes/Attributes.php
+++ b/src/CfdiUtils/Nodes/Attributes.php
@@ -87,6 +87,11 @@ class Attributes implements \Countable, \IteratorAggregate, \ArrayAccess
             return strval($value);
         }
         if (is_object($value) && is_callable([$value, '__toString'])) {
+            /**
+             * PHPStan false positive on cast object<Stringable> to string
+             * @noinspection PhpMultipleClassDeclarationsInspection
+             * @var \Stringable $value
+             */
             return strval($value);
         }
         throw new \InvalidArgumentException(sprintf('Cannot convert value of attribute %s to string', $key));

--- a/src/CfdiUtils/Retenciones/RetencionesCreator10.php
+++ b/src/CfdiUtils/Retenciones/RetencionesCreator10.php
@@ -38,6 +38,7 @@ class RetencionesCreator10 implements
 
     public function retenciones(): Retenciones
     {
+        /** @phpstan-var Retenciones PHPStan 1.10.13 identify retenciones as AbstractElement */
         return $this->retenciones;
     }
 

--- a/src/CfdiUtils/Retenciones/RetencionesCreator20.php
+++ b/src/CfdiUtils/Retenciones/RetencionesCreator20.php
@@ -38,6 +38,7 @@ class RetencionesCreator20 implements
 
     public function retenciones(): Retenciones
     {
+        /** @phpstan-var Retenciones PHPStan 1.10.13 identify retenciones as AbstractElement */
         return $this->retenciones;
     }
 

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/SelloDigitalCertificado.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/SelloDigitalCertificado.php
@@ -7,6 +7,7 @@ use CfdiUtils\Validate\Common\SelloDigitalCertificadoValidatorTrait;
 use CfdiUtils\Validate\Contracts\RequireXmlResolverInterface;
 use CfdiUtils\Validate\Contracts\RequireXmlStringInterface;
 use CfdiUtils\Validate\Contracts\RequireXsltBuilderInterface;
+use CfdiUtils\Validate\Status;
 
 /**
  * SelloDigitalCertificado
@@ -27,4 +28,16 @@ class SelloDigitalCertificado extends AbstractDiscoverableVersion33 implements
     RequireXsltBuilderInterface
 {
     use SelloDigitalCertificadoValidatorTrait;
+
+    protected function validateNombre(string $emisorNombre, string $rfc)
+    {
+        if ('' === $emisorNombre) {
+            return; // name is optional
+        }
+        $this->asserts->putStatus(
+            'SELLO04',
+            Status::when($this->compareNames($this->certificado->getName(), $emisorNombre)),
+            sprintf('Nombre certificado: %s, Nombre comprobante: %s.', $this->certificado->getName(), $emisorNombre)
+        );
+    }
 }

--- a/src/CfdiUtils/Validate/Cfdi40/Standard/SelloDigitalCertificado.php
+++ b/src/CfdiUtils/Validate/Cfdi40/Standard/SelloDigitalCertificado.php
@@ -7,6 +7,7 @@ use CfdiUtils\Validate\Common\SelloDigitalCertificadoValidatorTrait;
 use CfdiUtils\Validate\Contracts\RequireXmlResolverInterface;
 use CfdiUtils\Validate\Contracts\RequireXmlStringInterface;
 use CfdiUtils\Validate\Contracts\RequireXsltBuilderInterface;
+use CfdiUtils\Validate\Status;
 
 /**
  * SelloDigitalCertificado
@@ -27,4 +28,25 @@ class SelloDigitalCertificado extends AbstractDiscoverableVersion40 implements
     RequireXsltBuilderInterface
 {
     use SelloDigitalCertificadoValidatorTrait;
+
+    protected function validateNombre(string $emisorNombre, string $rfc)
+    {
+        if ('' === $emisorNombre) {
+            $this->asserts->putStatus('SELLO04', Status::error(), 'Nombre del emisor vacío');
+            return;
+        }
+
+        $isMoralPerson = 12 === mb_strlen($rfc);
+        if ($isMoralPerson) {
+            $explanation = 'No es posible realizar la validación en Personas Morales';
+            $this->asserts->putStatus('SELLO04', Status::none(), $explanation);
+            return;
+        }
+
+        $this->asserts->putStatus(
+            'SELLO04',
+            Status::when($this->certificado->getName() === $emisorNombre),
+            sprintf('Nombre certificado: %s, Nombre comprobante: %s.', $this->certificado->getName(), $emisorNombre)
+        );
+    }
 }

--- a/src/CfdiUtils/Validate/Common/SelloDigitalCertificadoValidatorTrait.php
+++ b/src/CfdiUtils/Validate/Common/SelloDigitalCertificadoValidatorTrait.php
@@ -72,7 +72,10 @@ trait SelloDigitalCertificadoValidatorTrait
             // validate emisor rfc
             $this->validateRfc($comprobante->searchAttribute('cfdi:Emisor', 'Rfc'));
             // validate emisor nombre
-            $this->validateNombre($comprobante->searchAttribute('cfdi:Emisor', 'Nombre'));
+            $this->validateNombre(
+                $comprobante->searchAttribute('cfdi:Emisor', 'Nombre'),
+                $comprobante->searchAttribute('cfdi:Emisor', 'Rfc')
+            );
         }
         $this->validateFecha($comprobante['Fecha']);
 
@@ -106,17 +109,8 @@ trait SelloDigitalCertificadoValidatorTrait
         );
     }
 
-    private function validateNombre(string $emisorNombre)
-    {
-        if ('' === $emisorNombre) {
-            return;
-        }
-        $this->asserts->putStatus(
-            'SELLO04',
-            Status::when($this->compareNames($this->certificado->getName(), $emisorNombre)),
-            sprintf('Nombre certificado: %s, Nombre comprobante: %s', $this->certificado->getName(), $emisorNombre)
-        );
-    }
+    /** @return void */
+    abstract protected function validateNombre(string $emisorNombre, string $rfc);
 
     private function validateFecha(string $fechaSource)
     {

--- a/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/GenkgoXslBuilderTest.php
@@ -10,9 +10,24 @@ final class GenkgoXslBuilderTest extends GenericBuilderTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+        // IGNORE DEPRECATION ERRORS SINCE PHP 8.1
+        if (PHP_VERSION_ID >= 80100) {
+            set_error_handler(function () {
+                return true;
+            }, E_DEPRECATED);
+        }
         if (! class_exists(XsltProcessor::class)) {
             $this->markTestSkipped('Genkgo/Xsl is not installed');
         }
+    }
+
+    protected function tearDown(): void
+    {
+        if (PHP_VERSION_ID >= 80100) {
+            restore_error_handler();
+        }
+        parent::tearDown();
     }
 
     protected function createBuilder(): XsltBuilderInterface

--- a/tests/CfdiUtilsTests/Utils/XmlTest.php
+++ b/tests/CfdiUtilsTests/Utils/XmlTest.php
@@ -10,7 +10,7 @@ final class XmlTest extends TestCase
 {
     public function testMethodNewDocumentContentWithInvalidXmlEncoding()
     {
-        $invalidXml = utf8_decode('<e a="ñ"></e>'); // the ñ is a special character
+        $invalidXml = mb_convert_encoding('<e a="ñ"></e>', 'ISO-8859-1', 'UTF-8'); // the ñ is a special character
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Cannot create a DOM Document from xml string'
             . PHP_EOL . 'XML Fatal [L: 1, C: 7]: Input is not proper UTF-8');

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SelloDigitalCertificadoTest.php
@@ -43,4 +43,17 @@ final class SelloDigitalCertificadoTest extends Validate33TestCase
         }
         $this->assertCount(8, $this->asserts, 'All 8 were are tested');
     }
+
+    public function testValidateWithEqualButNotIdenticalName()
+    {
+        //    change case, and punctuation to original name
+        //                   ESCUELA KEMPER URGATE SA DE CV
+        $this->setUpCertificado([], [
+            'Nombre' => 'ESCUELA "Kemper Urgate", S.A. DE C.V.',
+        ]);
+
+        $this->runValidate();
+
+        $this->assertStatusEqualsCode(Status::ok(), 'SELLO04');
+    }
 }

--- a/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SumasConceptosComprobanteImpuestosTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi33/Standard/SumasConceptosComprobanteImpuestosTest.php
@@ -145,8 +145,15 @@ final class SumasConceptosComprobanteImpuestosTest extends Validate33TestCase
                 'Importe' => '50.00',
             ]));
         }
+
         $this->runValidate();
-        $this->assertStatusEqualsCode(Status::error(), 'SUMAS07');
+        $assert = $this->getAssertByCodeOrFail('SUMAS07');
+
+        $this->assertTrue($assert->getStatus()->isError());
+        $this->assertEquals(
+            'No encontrados: 1 impuestos. Impuesto: XXX, TipoFactor: 0.050000, TasaOCuota: tasa, Importe: 50.00.',
+            $assert->getExplanation()
+        );
     }
 
     public function testValidateUnsetTotalImpuestosRetenidos()

--- a/tests/CfdiUtilsTests/Validate/Cfdi40/Standard/SelloDigitalCertificadoTest.php
+++ b/tests/CfdiUtilsTests/Validate/Cfdi40/Standard/SelloDigitalCertificadoTest.php
@@ -38,9 +38,77 @@ final class SelloDigitalCertificadoTest extends Validate40TestCase
     {
         $this->setupCfdiFile('cfdi40-valid.xml');
         $this->runValidate();
-        foreach (range(1, 8) as $i) {
-            $this->assertStatusEqualsCode(Status::ok(), 'SELLO0' . $i);
+        $expected = [
+            'SELLO01' => Status::ok(),
+            'SELLO02' => Status::ok(),
+            'SELLO03' => Status::ok(),
+            'SELLO04' => Status::none(),
+            'SELLO05' => Status::ok(),
+            'SELLO06' => Status::ok(),
+            'SELLO07' => Status::ok(),
+            'SELLO08' => Status::ok(),
+        ];
+        foreach ($expected as $code => $status) {
+            $this->assertStatusEqualsCode($status, $code);
         }
         $this->assertCount(8, $this->asserts, 'All 8 were are tested');
+    }
+
+    public function testValidateNameEmpty()
+    {
+        $this->setUpCertificado([], [
+            'Nombre' => '',
+        ]);
+
+        $this->runValidate();
+
+        $status = $this->getAssertByCodeOrFail('SELLO04');
+
+        $this->assertTrue($status->getStatus()->isError());
+        $this->assertSame('Nombre del emisor vacío', $status->getExplanation());
+    }
+
+    public function testValidateNameMoralPerson()
+    {
+        $this->setUpCertificado([], [
+            'Nombre' => 'ESCUELA KEMPER URGATE SA DE CV',
+        ]);
+
+        $this->runValidate();
+
+        $status = $this->getAssertByCodeOrFail('SELLO04');
+
+        $this->assertTrue($status->getStatus()->isNone());
+        $this->assertSame('No es posible realizar la validación en Personas Morales', $status->getExplanation());
+    }
+
+    public function testValidateWithIdenticalNameRegularPerson()
+    {
+        $this->setUpCertificado([], [
+            'Rfc' => 'COSC8001137NA', // set as persona física to force name comparison
+            'Nombre' => 'ESCUELA KEMPER URGATE SA DE CV',
+        ]);
+
+        $this->runValidate();
+
+        $this->assertStatusEqualsCode(Status::ok(), 'SELLO04');
+    }
+
+    public function testValidateWithoutIdenticalNameRegularPerson()
+    {
+        $this->setUpCertificado([], [
+            'Rfc' => 'COSC8001137NA',  // set as persona física to force name comparison
+            'Nombre' => 'ESCUELA KEMPER URGATE SA DE CV ',
+        ]);
+
+        $this->runValidate();
+
+        $status = $this->getAssertByCodeOrFail('SELLO04');
+
+        $this->assertTrue($status->getStatus()->isError());
+        $this->assertSame(
+            'Nombre certificado: ESCUELA KEMPER URGATE SA DE CV, Nombre comprobante: ESCUELA KEMPER URGATE SA DE CV .',
+            $status->getExplanation()
+        );
     }
 }

--- a/tests/CfdiUtilsTests/Validate/Common/SelloDigitalCertificadoWithRegularCertificadoTrait.php
+++ b/tests/CfdiUtilsTests/Validate/Common/SelloDigitalCertificadoWithRegularCertificadoTrait.php
@@ -53,19 +53,6 @@ trait SelloDigitalCertificadoWithRegularCertificadoTrait
         $this->assertStatusEqualsCode(Status::error(), 'SELLO04');
     }
 
-    public function testValidateWithEqualButNotIdenticalName()
-    {
-        //    change case, and punctuation to original name
-        //                   ESCUELA KEMPER URGATE SA DE CV
-        $this->setUpCertificado([], [
-            'Nombre' => 'ESCUELA - Kemper Urgate, S.A. DE C.V.',
-        ]);
-
-        $this->runValidate();
-
-        $this->assertStatusEqualsCode(Status::ok(), 'SELLO04');
-    }
-
     public function testValidateBadLowerFecha()
     {
         $validLowerDate = strtotime('2019-06-17T19:44:13+00:00');
@@ -124,6 +111,10 @@ trait SelloDigitalCertificadoWithRegularCertificadoTrait
         $validator = new class() {
             use SelloDigitalCertificadoValidatorTrait;
 
+            protected function validateNombre(string $emisorNombre, string $rfc)
+            {
+            }
+
             public function testCompareNames(string $first, string $second): bool
             {
                 return $this->compareNames($first, $second);
@@ -146,6 +137,10 @@ trait SelloDigitalCertificadoWithRegularCertificadoTrait
     {
         $validator = new class() {
             use SelloDigitalCertificadoValidatorTrait;
+
+            protected function validateNombre(string $emisorNombre, string $rfc)
+            {
+            }
 
             public function testCompareNames(string $first, string $second): bool
             {


### PR DESCRIPTION
- Fix `SELLO04` false positives on CFDI 4.0.
    - If name is empty then status is *error* since it is mandatory.
    - If *Persona Moral* then status is *none* since it is not possible to compare names.
    - If *Persona Física* then status is *ok* when name is **identical** to certificate name.
- Improve `SUMAS07` explanation.
- Fix PHPStan false positives.
- Update license year.
- Update `php-cs-fixer` configuration file.
- Fix `genkgo/xsl` dependency version.
- GitHub Workflow:
    - Add PHP 8.2 to test matrix.
    - Jobs run in PHP 8.2.
    - Remove development tools before install project dependencies.
- Fix build badge.
- When testing using Genkgo, ignore deprecation errors.
- Replace `utf8_decode` calls with `mb_convert_encoding`.
