### PR TITLE
Calculator for Pagos 2.0 and code style

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           fail-fast: true
       - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
     name: Code style (php-cs-fixer)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
           composer upgrade --no-interaction --no-progress --prefer-dist
       - name: PHPStan
-        run: phpstan analyse --no-progress --verbose src/ tests/
+        run: phpstan analyse --no-progress --verbose
 
   tests-linux:
     name: Test PHP ${{ matrix.php-versions }} on Linux

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,48 +1,53 @@
 <?php
 
+/**
+ * @noinspection PhpUndefinedClassInspection
+ * @noinspection PhpUndefinedNamespaceInspection
+ * @see https://cs.symfony.com/doc/ruleSets/
+ * @see https://cs.symfony.com/doc/rules/
+ */
+
 declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/.php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
-        '@PSR2' => true,
-        '@PHP70Migration' => true,
-        // '@PHP70Migration:risky' => true,
+        '@PSR12' => true,
+        // '@PSR12:risky' => true,
+        // '@PHP71Migration:risky' => true,
+        '@PHP73Migration' => true,
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
-        'no_alias_functions' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
+        'type_declaration_spaces' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'self_accessor' => true,
         'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
-        // contrib
         'concat_space' => ['spacing' => 'one'],
-        'not_operator_with_successor_space' => true,
-        'blank_lines_before_namespace' => true,
         'linebreak_after_opening_tag' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
+        'fully_qualified_strict_types' => true,
+        // symfony:risky
+        'no_alias_functions' => true,
+        'self_accessor' => true,
+        // contrib
+        'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
-            ->exclude(['vendor', 'build'])
+            ->append([__FILE__])
+            ->exclude(['vendor', 'build']),
     )
 ;

--- a/composer.json
+++ b/composer.json
@@ -70,11 +70,11 @@
         ],
         "dev:check-style": [
             "@php vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "@php vendor/bin/phpcs --colors -sp src/ tests/"
+            "@php vendor/bin/phpcs --colors -sp"
         ],
         "dev:fix-style": [
             "@php vendor/bin/php-cs-fixer fix --verbose",
-            "@php vendor/bin/phpcbf --colors -sp src/ tests/"
+            "@php vendor/bin/phpcbf --colors -sp"
         ],
         "dev:docs": [
             "node_modules/markdownlint-cli/markdownlint.js *.md docs/",

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "dev:test": [
             "@dev:check-style",
             "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "@php vendor/bin/phpstan analyse --no-progress src/ tests/"
+            "@php vendor/bin/phpstan analyse --no-progress"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"

--- a/development/bin/elements-maker.php
+++ b/development/bin/elements-maker.php
@@ -5,7 +5,7 @@ use CfdiUtils\Development\ElementsMaker\ElementsMaker;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-exit(call_user_func(new class(...$argv) extends BaseCliApplication {
+exit(call_user_func(new class (...$argv) extends BaseCliApplication {
     public function printHelp(): void
     {
         $command = basename($this->getCommand());

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,13 +32,17 @@
 - Merge methods from `\CfdiUtils\Nodes\NodeHasValueInterface` into `\CfdiUtils\Nodes\NodeInterface`.
 - Remove deprecated constant `CfdiUtils\Retenciones\Retenciones::RET_NAMESPACE`.
 
-## Version 2.24.0 2023-07-12
+## Version 2.24.1 2023-07-12
 
 Fix calculator for complement *Pagos 2.0*.
 For attributes `BaseP` and `ImporteP` the value was truncated. Now, the value has to be rounded.
 Some vendors communicate this change, such as Finkok.
 
 Improve calculator with new getter and setter for `paymentTaxesPrecision` and `currencies`.
+
+Update code style as other PhpCfdi projects.
+
+Set up PHPStan paths on configuration file.
 
 ## Maintenance 2023-06-19
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 Fix calculator for complement *Pagos 2.0*.
 For attributes `BaseP` and `ImporteP` the value was truncated. Now, the value has to be rounded.
-Some vendors communicate this change, such as Finkok. 
+Some vendors communicate this change, such as Finkok.
 
 Improve calculator with new getter and setter for `paymentTaxesPrecision` and `currencies`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,14 @@
 - Merge methods from `\CfdiUtils\Nodes\NodeHasValueInterface` into `\CfdiUtils\Nodes\NodeInterface`.
 - Remove deprecated constant `CfdiUtils\Retenciones\Retenciones::RET_NAMESPACE`.
 
+## Version 2.24.0 2023-07-12
+
+Fix calculator for complement *Pagos 2.0*.
+For attributes `BaseP` and `ImporteP` the value was truncated. Now, the value has to be rounded.
+Some vendors communicate this change, such as Finkok. 
+
+Improve calculator with new getter and setter for `paymentTaxesPrecision` and `currencies`.
+
 ## Maintenance 2023-06-19
 
 The certificate for RFC `EKU9003173C9` expired and is replaced for a new one.

--- a/docs/contribuir/guia-desarrollador.md
+++ b/docs/contribuir/guia-desarrollador.md
@@ -43,7 +43,7 @@ composer install
 Para probar que no se están violando las reglas de estilo
 
 ```shell
-vendor/bin/phpcs -sp --colors src/ tests/
+vendor/bin/phpcs -sp --colors
 vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --verbose
 ```
 
@@ -67,7 +67,7 @@ Para corregir todos los problemas de estilo que encuentre
 
 ```shell
 vendor/bin/php-cs-fixer fix --verbose
-vendor/bin/phpcbf --colors -sp src/ tests/
+vendor/bin/phpcbf --colors -sp
 ```
 
 

--- a/docs/contribuir/guia-desarrollador.md
+++ b/docs/contribuir/guia-desarrollador.md
@@ -57,7 +57,7 @@ vendor/bin/phpunit
 También ejecutamos PHPStan sobre archivos de orígenes y pruebas
 
 ```shell
-vendor/bin/phpstan analyse --level max src/ tests/
+vendor/bin/phpstan analyse
 ```
 
 

--- a/docs/contribuir/guia-windows.md
+++ b/docs/contribuir/guia-windows.md
@@ -41,11 +41,11 @@ Para que puedas ejecutar los comandos que forman las pruebas del proyecto (lo "c
 
 ```shell
 :: verificar que se están compliendo las reglas de estilo
-vendor\bin\phpcs -sp src tests
+vendor\bin\phpcs -sp
 vendor\bin\php-cs-fixer fix --dry-run --verbose
 
 :: hacer las correcciones de estilo de forma automática
-vendor\bin\phpcbf -sp src tests
+vendor\bin\phpcbf -sp
 vendor\bin\php-cs-fixer fix --verbose
 
 
@@ -53,7 +53,7 @@ vendor\bin\php-cs-fixer fix --verbose
 vendor\bin\phpunit
 
 :: ejecutar el analizador el analizador estático
-vendor\bin\phpstan.bat --no-progress analyse --level max src tests
+vendor\bin\phpstan.bat --no-progress analyse
 ```
 
 Lamentablemente, no se puede ejecutar `composer dev:build` o alguno de los comandos personalizados

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,11 +1,17 @@
 <?xml version="1.0"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
+
+    <file>src</file>
+    <file>tests</file>
+
     <arg name="tab-width" value="4"/>
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
-    <rule ref="PSR2" />
+    <arg name="cache" value="build/phpcs.cache"/>
+
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,6 @@
 parameters:
   level: 5
   inferPrivatePropertyTypeFromConstructor: true
-
+  paths:
+    - src/
+    - tests/

--- a/src/CfdiUtils/CadenaOrigen/CfdiDefaultLocations.php
+++ b/src/CfdiUtils/CadenaOrigen/CfdiDefaultLocations.php
@@ -4,11 +4,11 @@ namespace CfdiUtils\CadenaOrigen;
 
 class CfdiDefaultLocations
 {
-    const XSLT_32 = 'http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_2/cadenaoriginal_3_2.xslt';
+    public const XSLT_32 = 'http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_2/cadenaoriginal_3_2.xslt';
 
-    const XSLT_33 = 'http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt';
+    public const XSLT_33 = 'http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt';
 
-    const XSLT_40 = 'http://www.sat.gob.mx/sitio_internet/cfd/4/cadenaoriginal_4_0/cadenaoriginal_4_0.xslt';
+    public const XSLT_40 = 'http://www.sat.gob.mx/sitio_internet/cfd/4/cadenaoriginal_4_0/cadenaoriginal_4_0.xslt';
 
     public static function location(string $version): string
     {

--- a/src/CfdiUtils/CfdiCreatorTrait.php
+++ b/src/CfdiUtils/CfdiCreatorTrait.php
@@ -32,11 +32,11 @@ trait CfdiCreatorTrait
         XsltBuilderInterface $xsltBuilder = null
     ): void {
         $this->comprobante->addAttributes($comprobanteAttributes);
-        $this->setXmlResolver($xmlResolver ? : new XmlResolver());
+        $this->setXmlResolver($xmlResolver ?: new XmlResolver());
         if (null !== $certificado) {
             $this->putCertificado($certificado);
         }
-        $this->setXsltBuilder($xsltBuilder ? : new DOMBuilder());
+        $this->setXsltBuilder($xsltBuilder ?: new DOMBuilder());
     }
 
     public static function newUsingNode(

--- a/src/CfdiUtils/Cleaner/BeforeLoad/RemoveDuplicatedCfdi3Namespace.php
+++ b/src/CfdiUtils/Cleaner/BeforeLoad/RemoveDuplicatedCfdi3Namespace.php
@@ -6,8 +6,10 @@ class RemoveDuplicatedCfdi3Namespace implements BeforeLoadCleanerInterface
 {
     public function clean(string $content): string
     {
-        if (false !== strpos($content, ' xmlns="http://www.sat.gob.mx/cfd/3"')
-            && false !== strpos($content, ' xmlns:cfdi="http://www.sat.gob.mx/cfd/3"')) {
+        if (
+            false !== strpos($content, ' xmlns="http://www.sat.gob.mx/cfd/3"')
+            && false !== strpos($content, ' xmlns:cfdi="http://www.sat.gob.mx/cfd/3"')
+        ) {
             $content = str_replace(' xmlns="http://www.sat.gob.mx/cfd/3"', '', $content);
         }
         return $content;

--- a/src/CfdiUtils/ConsultaCfdiSat/Config.php
+++ b/src/CfdiUtils/ConsultaCfdiSat/Config.php
@@ -8,7 +8,7 @@ class Config
      * Default value of SAT web service
      * @var string
      */
-    const DEFAULT_SERVICE_URL = 'https://consultaqr.facturaelectronica.sat.gob.mx/ConsultaCFDIService.svc';
+    public const DEFAULT_SERVICE_URL = 'https://consultaqr.facturaelectronica.sat.gob.mx/ConsultaCFDIService.svc';
 
     /**
      * This library does not use WSDL anymore
@@ -17,7 +17,7 @@ class Config
      * @see self::DEFAULT_SERVICE_URL
      * @var string
      */
-    const DEFAULT_WSDL_URL = 'https://consultaqr.facturaelectronica.sat.gob.mx/ConsultaCFDIService.svc?singleWsdl';
+    public const DEFAULT_WSDL_URL = self::DEFAULT_SERVICE_URL . '?singleWsdl';
 
     /** @var int */
     private $timeout;
@@ -39,7 +39,7 @@ class Config
     ) {
         $this->timeout = $timeout;
         $this->verifyPeer = $verifyPeer;
-        $this->serviceUrl = $serviceUrl ? : static::DEFAULT_SERVICE_URL;
+        $this->serviceUrl = $serviceUrl ?: static::DEFAULT_SERVICE_URL;
         $this->wsdlLocation = $wsdlLocation;
         if ('' !== $this->wsdlLocation) {
             trigger_error(__CLASS__ . ' deprecated WSDL location', E_USER_DEPRECATED);

--- a/src/CfdiUtils/ConsultaCfdiSat/WebService.php
+++ b/src/CfdiUtils/ConsultaCfdiSat/WebService.php
@@ -19,7 +19,7 @@ class WebService
 
     public function __construct(Config $config = null)
     {
-        $this->config = $config ? : new Config();
+        $this->config = $config ?: new Config();
     }
 
     public function getConfig(): Config

--- a/src/CfdiUtils/OpenSSL/Caller.php
+++ b/src/CfdiUtils/OpenSSL/Caller.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class Caller
 {
-    const DEFAULT_OPENSSL_EXECUTABLE = 'openssl';
+    public const DEFAULT_OPENSSL_EXECUTABLE = 'openssl';
 
     /** @var string */
     private $executable;

--- a/src/CfdiUtils/Retenciones/Retenciones.php
+++ b/src/CfdiUtils/Retenciones/Retenciones.php
@@ -29,7 +29,7 @@ class Retenciones
      * @deprecated :3.0.0
      * @internal Preserve this constant to not break compatibility
      */
-    const RET_NAMESPACE = 'http://www.sat.gob.mx/esquemas/retencionpago/1';
+    public const RET_NAMESPACE = 'http://www.sat.gob.mx/esquemas/retencionpago/1';
 
     /** @var array<string, string> Dictionary of versions and namespaces  */
     private const RET_SPECS = [

--- a/src/CfdiUtils/Retenciones/RetencionesCreatorTrait.php
+++ b/src/CfdiUtils/Retenciones/RetencionesCreatorTrait.php
@@ -33,11 +33,11 @@ trait RetencionesCreatorTrait
         XsltBuilderInterface $xsltBuilder = null
     ): void {
         $this->retenciones->addAttributes($retencionesAttributes);
-        $this->setXmlResolver($xmlResolver ? : new XmlResolver());
+        $this->setXmlResolver($xmlResolver ?: new XmlResolver());
         if (null !== $certificado) {
             $this->putCertificado($certificado);
         }
-        $this->setXsltBuilder($xsltBuilder ? : new DOMBuilder());
+        $this->setXsltBuilder($xsltBuilder ?: new DOMBuilder());
     }
 
     public function addSello(string $key, string $passPhrase = '')

--- a/src/CfdiUtils/SumasConceptos/SumasConceptosWriter.php
+++ b/src/CfdiUtils/SumasConceptos/SumasConceptosWriter.php
@@ -63,8 +63,10 @@ class SumasConceptosWriter
         $this->comprobante['SubTotal'] = $this->format($this->sumas->getSubTotal());
         $this->comprobante['Total'] = $this->format($this->sumas->getTotal());
         $this->comprobante['Descuento'] = $this->format($this->sumas->getDescuento());
-        if (! $this->sumas->foundAnyConceptWithDiscount()
-            && ! $this->valueGreaterThanZero($this->sumas->getDescuento())) {
+        if (
+            ! $this->sumas->foundAnyConceptWithDiscount()
+            && ! $this->valueGreaterThanZero($this->sumas->getDescuento())
+        ) {
             unset($this->comprobante['Descuento']);
         }
     }
@@ -74,7 +76,8 @@ class SumasConceptosWriter
         // obtain node reference
         $impuestos = $this->comprobante->getImpuestos();
         // if there is nothing to write then remove the children and exit
-        if (! $this->sumas->hasTraslados()
+        if (
+            ! $this->sumas->hasTraslados()
             && ! $this->sumas->hasRetenciones()
             && ! ($this->writeExentos && $this->sumas->hasExentos())
         ) {

--- a/src/CfdiUtils/SumasPagos20/Calculator.php
+++ b/src/CfdiUtils/SumasPagos20/Calculator.php
@@ -8,15 +8,35 @@ use CfdiUtils\Nodes\Nodes;
 class Calculator
 {
     /** @var int */
-    private $paymentTaxesTruncate;
+    private $paymentTaxesPrecision;
 
     /** @var Currencies */
     private $currencies;
 
-    public function __construct(int $paymentTaxesTruncate = 6, Currencies $currencies = null)
+    public function __construct(int $paymentTaxesPrecision = 6, ?Currencies $currencies = null)
     {
-        $this->paymentTaxesTruncate = min(6, max(0, $paymentTaxesTruncate));
+        $this->setPaymentTaxesPrecision($paymentTaxesPrecision);
         $this->currencies = $currencies ?? new Currencies(['MXN' => 2, 'USD' => 2]);
+    }
+
+    public function getPaymentTaxesPrecision(): int
+    {
+        return $this->paymentTaxesPrecision;
+    }
+
+    public function setPaymentTaxesPrecision(int $paymentTaxesPrecision): void
+    {
+        $this->paymentTaxesPrecision = min(6, max(0, $paymentTaxesPrecision));
+    }
+
+    public function getCurrencies(): Currencies
+    {
+        return $this->currencies;
+    }
+
+    public function setCurrencies(Currencies $currencies): void
+    {
+        $this->currencies = $currencies;
     }
 
     public function calculate(NodeInterface $nodePagos): Pagos
@@ -41,7 +61,7 @@ class Calculator
         }
         $montoMinimo = $sumMonto->truncate($this->currencies->get($nodePago['MonedaP']));
         $monto = (isset($nodePago['Monto'])) ? new Decimal($nodePago['Monto']) : $montoMinimo;
-        $impuestos = $impuestos->truncate($this->paymentTaxesTruncate);
+        $impuestos = $impuestos->round($this->paymentTaxesPrecision);
         $tipoCambioP = new Decimal($nodePago['TipoCambioP']);
         return new Pago($monto, $montoMinimo, $tipoCambioP, $impuestos);
     }

--- a/src/CfdiUtils/SumasPagos20/Decimal.php
+++ b/src/CfdiUtils/SumasPagos20/Decimal.php
@@ -8,7 +8,7 @@ use JsonSerializable;
 
 final class Decimal implements JsonSerializable
 {
-    const SCALE = 24;
+    public const SCALE = 24;
 
     /** @var string */
     private $value;

--- a/src/CfdiUtils/TimbreFiscalDigital/TfdCadenaDeOrigen.php
+++ b/src/CfdiUtils/TimbreFiscalDigital/TfdCadenaDeOrigen.php
@@ -15,14 +15,14 @@ class TfdCadenaDeOrigen implements XmlResolverPropertyInterface, XsltBuilderProp
     use XmlResolverPropertyTrait;
     use XsltBuilderPropertyTrait;
 
-    const TFD_10 = 'http://www.sat.gob.mx/sitio_internet/timbrefiscaldigital/cadenaoriginal_TFD_1_0.xslt';
+    public const TFD_10 = 'http://www.sat.gob.mx/sitio_internet/timbrefiscaldigital/cadenaoriginal_TFD_1_0.xslt';
 
-    const TFD_11 = 'http://www.sat.gob.mx/sitio_internet/cfd/TimbreFiscalDigital/cadenaoriginal_TFD_1_1.xslt';
+    public const TFD_11 = 'http://www.sat.gob.mx/sitio_internet/cfd/TimbreFiscalDigital/cadenaoriginal_TFD_1_1.xslt';
 
     public function __construct(XmlResolver $xmlResolver = null, XsltBuilderInterface $xsltBuilder = null)
     {
-        $this->setXmlResolver($xmlResolver ? : new XmlResolver());
-        $this->setXsltBuilder($xsltBuilder ? : new DOMBuilder());
+        $this->setXmlResolver($xmlResolver ?: new XmlResolver());
+        $this->setXsltBuilder($xsltBuilder ?: new DOMBuilder());
     }
 
     public function build(string $tdfXmlString, string $version = ''): string

--- a/src/CfdiUtils/Utils/Rfc.php
+++ b/src/CfdiUtils/Utils/Rfc.php
@@ -4,13 +4,13 @@ namespace CfdiUtils\Utils;
 
 class Rfc
 {
-    const RFC_GENERIC = 'XAXX010101000';
+    public const RFC_GENERIC = 'XAXX010101000';
 
-    const RFC_FOREIGN = 'XEXX010101000';
+    public const RFC_FOREIGN = 'XEXX010101000';
 
-    const DISALLOW_GENERIC = 1;
+    public const DISALLOW_GENERIC = 1;
 
-    const DISALLOW_FOREIGN = 2;
+    public const DISALLOW_FOREIGN = 2;
 
     /** @var string */
     private $rfc;

--- a/src/CfdiUtils/Validate/Assert.php
+++ b/src/CfdiUtils/Validate/Assert.php
@@ -30,7 +30,7 @@ class Assert
         }
         $this->code = $code;
         $this->title = $title;
-        $this->setStatus($status ? : Status::none());
+        $this->setStatus($status ?: Status::none());
         $this->explanation = $explanation;
     }
 

--- a/src/CfdiUtils/Validate/Cfdi33/Abstracts/AbstractRecepcionPagos10.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Abstracts/AbstractRecepcionPagos10.php
@@ -19,7 +19,8 @@ abstract class AbstractRecepcionPagos10 extends AbstractVersion33 implements Dis
     {
         // do not run anything if not found
         $pagos10 = $comprobante->searchNode('cfdi:Complemento', 'pago10:Pagos');
-        if ('3.3' !== $comprobante['Version']
+        if (
+            '3.3' !== $comprobante['Version']
             || 'P' !== $comprobante['TipoDeComprobante']
             || null === $pagos10
             || '1.0' !== $pagos10['Version']

--- a/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Conceptos.php
+++ b/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Conceptos.php
@@ -16,17 +16,17 @@ use CfdiUtils\Validate\Status;
  */
 class Conceptos extends AbstractRecepcionPagos10
 {
-    const REQUIRED_CLAVEPRODSERV = '84111506';
+    public const REQUIRED_CLAVEPRODSERV = '84111506';
 
-    const REQUIRED_CANTIDAD = '1';
+    public const REQUIRED_CANTIDAD = '1';
 
-    const REQUIRED_CLAVEUNIDAD = 'ACT';
+    public const REQUIRED_CLAVEUNIDAD = 'ACT';
 
-    const REQUIRED_DESCRIPCION = 'Pago';
+    public const REQUIRED_DESCRIPCION = 'Pago';
 
-    const REQUIRED_VALORUNITARIO = '0';
+    public const REQUIRED_VALORUNITARIO = '0';
 
-    const REQUIRED_IMPORTE = '0';
+    public const REQUIRED_IMPORTE = '0';
 
     public function validateRecepcionPagos(NodeInterface $comprobante, Asserts $asserts)
     {

--- a/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioValor.php
+++ b/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/DoctoRelacionado/TipoCambioValor.php
@@ -19,9 +19,11 @@ class TipoCambioValor extends AbstractDoctoRelacionadoValidator
     {
         $pago = $this->getPago();
 
-        if ('MXN' === $docto['MonedaDR']
+        if (
+            'MXN' === $docto['MonedaDR']
             && $pago['MonedaP'] !== $docto['MonedaDR']
-            && '1' !== $docto['TipoCambioDR']) {
+            && '1' !== $docto['TipoCambioDR']
+        ) {
             throw $this->exception(sprintf(
                 'Moneda pago: "%s", Moneda documento: "%s", Tipo cambio docto: "%s"',
                 $pago['MonedaP'],

--- a/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCadena.php
+++ b/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCadena.php
@@ -17,8 +17,10 @@ class TipoCadenaPagoCadena extends AbstractPagoValidator
 
     public function validatePago(NodeInterface $pago): bool
     {
-        if ((('' !== $pago['TipoCadPago']) xor ('' !== $pago['CadPago']))
-            || ($pago->offsetExists('TipoCadPago') xor $pago->offsetExists('CadPago'))) {
+        if (
+            (('' !== $pago['TipoCadPago']) xor ('' !== $pago['CadPago']))
+            || ($pago->offsetExists('TipoCadPago') xor $pago->offsetExists('CadPago'))
+        ) {
             throw new ValidatePagoException(
                 sprintf('Tipo cadena pago: "%s", Cadena: "%s"', $pago['TipoCadPago'], $pago['CadPago'])
             );

--- a/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCertificado.php
+++ b/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoCertificado.php
@@ -17,8 +17,10 @@ class TipoCadenaPagoCertificado extends AbstractPagoValidator
 
     public function validatePago(NodeInterface $pago): bool
     {
-        if ((('' !== $pago['TipoCadPago']) xor ('' !== $pago['CertPago']))
-            || ($pago->offsetExists('TipoCadPago') xor $pago->offsetExists('CertPago'))) {
+        if (
+            (('' !== $pago['TipoCadPago']) xor ('' !== $pago['CertPago']))
+            || ($pago->offsetExists('TipoCadPago') xor $pago->offsetExists('CertPago'))
+        ) {
             throw new ValidatePagoException(
                 sprintf('Tipo cadena pago: "%s", Certificado: "%s"', $pago['TipoCadPago'], $pago['CertPago'])
             );

--- a/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoSello.php
+++ b/src/CfdiUtils/Validate/Cfdi33/RecepcionPagos/Pagos/TipoCadenaPagoSello.php
@@ -17,8 +17,10 @@ class TipoCadenaPagoSello extends AbstractPagoValidator
 
     public function validatePago(NodeInterface $pago): bool
     {
-        if ((('' !== $pago['TipoCadPago']) xor ('' !== $pago['SelloPago']))
-            || ($pago->offsetExists('TipoCadPago') xor $pago->offsetExists('SelloPago'))) {
+        if (
+            (('' !== $pago['TipoCadPago']) xor ('' !== $pago['SelloPago']))
+            || ($pago->offsetExists('TipoCadPago') xor $pago->offsetExists('SelloPago'))
+        ) {
             throw new ValidatePagoException(
                 sprintf('Tipo cadena pago: "%s", Sello: "%s"', $pago['TipoCadPago'], $pago['SelloPago'])
             );

--- a/src/CfdiUtils/Validate/Cfdi33/Standard/ConceptoImpuestos.php
+++ b/src/CfdiUtils/Validate/Cfdi33/Standard/ConceptoImpuestos.php
@@ -103,8 +103,10 @@ class ConceptoImpuestos extends AbstractDiscoverableVersion33
         if (null === $impuestos) {
             return true;
         }
-        if ($impuestos->searchNodes('cfdi:Traslados', 'cfdi:Traslado')->count()
-            || $impuestos->searchNodes('cfdi:Retenciones', 'cfdi:Retencion')->count()) {
+        if (
+            $impuestos->searchNodes('cfdi:Traslados', 'cfdi:Traslado')->count()
+            || $impuestos->searchNodes('cfdi:Retenciones', 'cfdi:Retencion')->count()
+        ) {
             return true;
         }
         return false;

--- a/src/CfdiUtils/Validate/CfdiValidatorTrait.php
+++ b/src/CfdiUtils/Validate/CfdiValidatorTrait.php
@@ -26,8 +26,8 @@ trait CfdiValidatorTrait
      */
     public function __construct(XmlResolver $xmlResolver = null, XsltBuilderInterface $xsltBuilder = null)
     {
-        $this->setXmlResolver($xmlResolver ? : new XmlResolver());
-        $this->setXsltBuilder($xsltBuilder ? : new DOMBuilder());
+        $this->setXmlResolver($xmlResolver ?: new XmlResolver());
+        $this->setXsltBuilder($xsltBuilder ?: new DOMBuilder());
     }
 
     /**

--- a/src/CfdiUtils/Validate/Common/SelloDigitalCertificadoValidatorTrait.php
+++ b/src/CfdiUtils/Validate/Common/SelloDigitalCertificadoValidatorTrait.php
@@ -13,15 +13,15 @@ use CfdiUtils\XmlResolver\XmlResolverPropertyTrait;
 
 trait SelloDigitalCertificadoValidatorTrait
 {
+    use XmlResolverPropertyTrait;
+    use XmlStringPropertyTrait;
+    use XsltBuilderPropertyTrait;
+
     /** @var Asserts */
     private $asserts;
 
     /** @var Certificado */
     private $certificado;
-
-    use XmlResolverPropertyTrait;
-    use XmlStringPropertyTrait;
-    use XsltBuilderPropertyTrait;
 
     private function registerAsserts()
     {

--- a/src/CfdiUtils/Validate/MultiValidatorFactory.php
+++ b/src/CfdiUtils/Validate/MultiValidatorFactory.php
@@ -12,7 +12,7 @@ class MultiValidatorFactory
 
     public function __construct(Discoverer $discoverer = null)
     {
-        $this->discoverer = $discoverer ? : new Discoverer();
+        $this->discoverer = $discoverer ?: new Discoverer();
     }
 
     public function getDiscoverer(): Discoverer

--- a/src/CfdiUtils/Validate/Status.php
+++ b/src/CfdiUtils/Validate/Status.php
@@ -8,15 +8,15 @@ namespace CfdiUtils\Validate;
  */
 class Status
 {
-    const STATUS_ERROR = 'ERROR';
+    public const STATUS_ERROR = 'ERROR';
 
-    const STATUS_WARNING = 'WARN';
+    public const STATUS_WARNING = 'WARN';
 
-    const STATUS_NONE = 'NONE';
+    public const STATUS_NONE = 'NONE';
 
-    const STATUS_OK = 'OK';
+    public const STATUS_OK = 'OK';
 
-    const ORDER_MAP = [
+    public const ORDER_MAP = [
         self::STATUS_ERROR => 1,
         self::STATUS_WARNING => 2,
         self::STATUS_NONE => 3,
@@ -28,8 +28,10 @@ class Status
     public function __construct(string $value)
     {
         // using values as keys for speed access
-        if (self::STATUS_ERROR !== $value && self::STATUS_WARNING !== $value
-            && self::STATUS_OK !== $value && self::STATUS_NONE !== $value) {
+        if (
+            self::STATUS_ERROR !== $value && self::STATUS_WARNING !== $value
+            && self::STATUS_OK !== $value && self::STATUS_NONE !== $value
+        ) {
             throw new \UnexpectedValueException('The status is not one of the defined valid constants');
         }
         $this->status = $value;
@@ -77,7 +79,7 @@ class Status
 
     public static function when(bool $condition, self $errorStatus = null): self
     {
-        return ($condition) ? self::ok() : ($errorStatus ? : self::error());
+        return ($condition) ? self::ok() : ($errorStatus ?: self::error());
     }
 
     public function equalsTo(self $status): bool

--- a/src/CfdiUtils/VersionDiscovery/StaticMethodsCompatTrait.php
+++ b/src/CfdiUtils/VersionDiscovery/StaticMethodsCompatTrait.php
@@ -2,9 +2,9 @@
 
 namespace CfdiUtils\VersionDiscovery;
 
-use \DOMDocument;
-use \DOMElement;
 use CfdiUtils\Nodes\NodeInterface;
+use DOMDocument;
+use DOMElement;
 
 /**
  * Use this trait for compatibility only, all methods are deprecated.

--- a/src/CfdiUtils/XmlResolver/XmlResolver.php
+++ b/src/CfdiUtils/XmlResolver/XmlResolver.php
@@ -21,11 +21,11 @@ class XmlResolver
     /** @var DownloaderInterface */
     private $downloader;
 
-    const TYPE_XSD = 'XSD';
+    public const TYPE_XSD = 'XSD';
 
-    const TYPE_XSLT = 'XSLT';
+    public const TYPE_XSLT = 'XSLT';
 
-    const TYPE_CER = 'CER';
+    public const TYPE_CER = 'CER';
 
     /**
      * XmlResolver constructor.

--- a/tests/CfdiUtilsTests/CadenaOrigen/XsltBuilderPropertyTest.php
+++ b/tests/CfdiUtilsTests/CadenaOrigen/XsltBuilderPropertyTest.php
@@ -34,7 +34,7 @@ final class XsltBuilderPropertyTest extends TestCase
 
     protected function createImplementation(): XsltBuilderPropertyInterface
     {
-        return new class() implements XsltBuilderPropertyInterface {
+        return new class () implements XsltBuilderPropertyInterface {
             use XsltBuilderPropertyTrait;
         };
     }

--- a/tests/CfdiUtilsTests/Certificado/CertificadoPropertyTest.php
+++ b/tests/CfdiUtilsTests/Certificado/CertificadoPropertyTest.php
@@ -11,7 +11,7 @@ final class CertificadoPropertyTest extends TestCase
 {
     public function testCertificadoProperty()
     {
-        $implementation = new class() implements CertificadoPropertyInterface {
+        $implementation = new class () implements CertificadoPropertyInterface {
             use CertificadoPropertyTrait;
         };
 

--- a/tests/CfdiUtilsTests/CfdiVersionTest.php
+++ b/tests/CfdiUtilsTests/CfdiVersionTest.php
@@ -11,7 +11,7 @@ final class CfdiVersionTest extends TestCase
 {
     public function testCreateDiscoverer(): void
     {
-        $extended = new class() extends CfdiVersion {
+        $extended = new class () extends CfdiVersion {
             public static function exposeCreateDiscoverer(): VersionDiscoverer
             {
                 return static::createDiscoverer();

--- a/tests/CfdiUtilsTests/Cleaner/BeforeLoad/BeforeLoadCleanerTest.php
+++ b/tests/CfdiUtilsTests/Cleaner/BeforeLoad/BeforeLoadCleanerTest.php
@@ -22,13 +22,13 @@ final class BeforeLoadCleanerTest extends TestCase
 
     public function testCleanCallsCleaners()
     {
-        $returnFoo = new class() implements BeforeLoadCleanerInterface {
+        $returnFoo = new class () implements BeforeLoadCleanerInterface {
             public function clean(string $content): string
             {
                 return str_replace('foo', 'FOO', $content);
             }
         };
-        $returnBar = new class() implements BeforeLoadCleanerInterface {
+        $returnBar = new class () implements BeforeLoadCleanerInterface {
             public function clean(string $content): string
             {
                 return str_replace('bar', 'BAR', $content);

--- a/tests/CfdiUtilsTests/Nodes/AttributesTest.php
+++ b/tests/CfdiUtilsTests/Nodes/AttributesTest.php
@@ -189,7 +189,7 @@ final class AttributesTest extends TestCase
     public function testSetWithObjectToString()
     {
         $expectedValue = 'foo';
-        $toStringObject = new class('foo') {
+        $toStringObject = new class ('foo') {
             /** @var string */
             private $value;
 

--- a/tests/CfdiUtilsTests/OpenSSL/CallerTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/CallerTest.php
@@ -42,7 +42,7 @@ final class CallerTest extends TestCase
         $process->method('getOutput')->willReturn($output);
         $process->method('getErrorOutput')->willReturn($errors);
 
-        return new class($process) extends Caller {
+        return new class ($process) extends Caller {
             /** @var Process */
             private $process;
 

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLPropertyTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLPropertyTest.php
@@ -10,7 +10,7 @@ final class OpenSSLPropertyTest extends TestCase
 {
     public function testCorrectImplementer()
     {
-        $object = new class() {
+        $object = new class () {
             use OpenSSLPropertyTrait;
 
             public function __construct(OpenSSL $openSSL = null)
@@ -24,7 +24,7 @@ final class OpenSSLPropertyTest extends TestCase
 
     public function testNotInstantiatedImplementer()
     {
-        $object = new class() {
+        $object = new class () {
             use OpenSSLPropertyTrait;
         };
 
@@ -35,7 +35,7 @@ final class OpenSSLPropertyTest extends TestCase
 
     public function testWithDefaultSetterVisibility()
     {
-        $object = new class() {
+        $object = new class () {
             use OpenSSLPropertyTrait;
         };
         $this->assertFalse(is_callable([$object, 'setOpenSSL']), 'setOpenSSL must not be public accesible');

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckInputFileTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckInputFileTest.php
@@ -10,7 +10,7 @@ final class OpenSSLProtectedMethodCheckInputFileTest extends TestCase
 {
     private function openSSL(): object
     {
-        return new class() extends OpenSSL {
+        return new class () extends OpenSSL {
             public function checkInputFile(string $path)
             {
                 parent::checkInputFile($path);

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckOutputFileTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckOutputFileTest.php
@@ -10,7 +10,7 @@ final class OpenSSLProtectedMethodCheckOutputFileTest extends TestCase
 {
     private function openSSL(): object
     {
-        return new class() extends OpenSSL {
+        return new class () extends OpenSSL {
             public function checkOutputFile(string $path)
             {
                 parent::checkOutputFile($path);

--- a/tests/CfdiUtilsTests/QuickReader/QuickReaderImporterTest.php
+++ b/tests/CfdiUtilsTests/QuickReader/QuickReaderImporterTest.php
@@ -5,7 +5,6 @@ namespace CfdiUtilsTests\QuickReader;
 use CfdiUtils\QuickReader\QuickReader;
 use CfdiUtils\QuickReader\QuickReaderImporter;
 use DOMDocument;
-
 use PHPUnit\Framework\TestCase;
 
 final class QuickReaderImporterTest extends TestCase

--- a/tests/CfdiUtilsTests/QuickReader/QuickReaderTest.php
+++ b/tests/CfdiUtilsTests/QuickReader/QuickReaderTest.php
@@ -3,7 +3,6 @@
 namespace CfdiUtilsTests\QuickReader;
 
 use CfdiUtils\QuickReader\QuickReader;
-
 use PHPUnit\Framework\TestCase;
 
 final class QuickReaderTest extends TestCase

--- a/tests/CfdiUtilsTests/Retenciones/RetencionVersionTest.php
+++ b/tests/CfdiUtilsTests/Retenciones/RetencionVersionTest.php
@@ -12,7 +12,7 @@ final class RetencionVersionTest extends TestCase
 {
     public function testCreateDiscoverer(): void
     {
-        $extended = new class() extends RetencionVersion {
+        $extended = new class () extends RetencionVersion {
             public static function exposeCreateDiscoverer(): VersionDiscoverer
             {
                 return static::createDiscoverer();

--- a/tests/CfdiUtilsTests/Retenciones/RetencionesTest.php
+++ b/tests/CfdiUtilsTests/Retenciones/RetencionesTest.php
@@ -9,13 +9,13 @@ use CfdiUtilsTests\TestCase;
 
 final class RetencionesTest extends TestCase
 {
-    const XML_MINIMAL_DEFINITION = <<<XML
-<retenciones:Retenciones xmlns:retenciones="http://www.sat.gob.mx/esquemas/retencionpago/1" Version="1.0"/>
-XML;
+    public const XML_MINIMAL_DEFINITION = <<<XML
+        <retenciones:Retenciones xmlns:retenciones="http://www.sat.gob.mx/esquemas/retencionpago/1" Version="1.0"/>
+        XML;
 
-    const XML_20_MINIMAL_DEFINITION = <<<XML
-<retenciones:Retenciones xmlns:retenciones="http://www.sat.gob.mx/esquemas/retencionpago/2" Version="2.0"/>
-XML;
+    public const XML_20_MINIMAL_DEFINITION = <<<XML
+        <retenciones:Retenciones xmlns:retenciones="http://www.sat.gob.mx/esquemas/retencionpago/2" Version="2.0"/>
+        XML;
 
     public function providerRetencionesVersionNamespace(): array
     {

--- a/tests/CfdiUtilsTests/SumasPagos20/DecimalTest.php
+++ b/tests/CfdiUtilsTests/SumasPagos20/DecimalTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CfdiUtilsTests\SumasPagos20;
+
+use CfdiUtils\SumasPagos20\Decimal;
+use CfdiUtilsTests\TestCase;
+
+final class DecimalTest extends TestCase
+{
+    /** @return array<array{Decimal, Decimal, int}> */
+    public function providerRound(): array
+    {
+        return [
+            [new Decimal('45740.35'), new Decimal('45740.3490'), 2],
+            [new Decimal('1.23'), new Decimal('1.234'), 2],
+            [new Decimal('1.24'), new Decimal('1.235'), 2],
+            [new Decimal('1.24'), new Decimal('1.236'), 2],
+        ];
+    }
+
+    /** @dataProvider providerRound() */
+    public function testRound(Decimal $expected, Decimal $value, int $decimals): void
+    {
+        $this->assertTrue(0 === $expected->compareTo($value->round($decimals)));
+    }
+}

--- a/tests/CfdiUtilsTests/Validate/Common/SelloDigitalCertificadoWithRegularCertificadoTrait.php
+++ b/tests/CfdiUtilsTests/Validate/Common/SelloDigitalCertificadoWithRegularCertificadoTrait.php
@@ -112,7 +112,7 @@ trait SelloDigitalCertificadoWithRegularCertificadoTrait
      */
     public function testCompareNamesBasicChars(bool $expected, string $first, string $second)
     {
-        $validator = new class() {
+        $validator = new class () {
             use SelloDigitalCertificadoValidatorTrait;
 
             protected function validateNombre(string $emisorNombre, string $rfc)
@@ -139,7 +139,7 @@ trait SelloDigitalCertificadoWithRegularCertificadoTrait
      */
     public function testCompareNamesExtendedChars(string $first, string $second)
     {
-        $validator = new class() {
+        $validator = new class () {
             use SelloDigitalCertificadoValidatorTrait;
 
             protected function validateNombre(string $emisorNombre, string $rfc)

--- a/tests/CfdiUtilsTests/XmlResolver/XmlResolverPropertyTraitTest.php
+++ b/tests/CfdiUtilsTests/XmlResolver/XmlResolverPropertyTraitTest.php
@@ -15,7 +15,7 @@ final class XmlResolverPropertyTraitTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->specimen = new class() implements XmlResolverPropertyInterface {
+        $this->specimen = new class () implements XmlResolverPropertyInterface {
             use XmlResolverPropertyTrait;
         };
     }

--- a/tests/CfdiUtilsTests/XmlResolver/XmlResolverTest.php
+++ b/tests/CfdiUtilsTests/XmlResolver/XmlResolverTest.php
@@ -114,7 +114,7 @@ final class XmlResolverTest extends TestCase
         $remoteUrl = $cerNumber->remoteUrl();
 
         // this downloader will throw an exception if downloadTo is called
-        $nullDownloader = new class() implements DownloaderInterface {
+        $nullDownloader = new class () implements DownloaderInterface {
             public function downloadTo(string $source, string $destination)
             {
                 throw new \RuntimeException("$source will not be downloaded to $destination");

--- a/tests/assets/pagos20-calculator/004.xml
+++ b/tests/assets/pagos20-calculator/004.xml
@@ -312,7 +312,7 @@
         </pago20:DoctoRelacionado>
         <pago20:ImpuestosP>
           <pago20:TrasladosP>
-            <pago20:TrasladoP ImpuestoP="002" TipoFactorP="Tasa" TasaOCuotaP="0.160000" BaseP="1089653.476923" ImporteP="174344.556310"/>
+            <pago20:TrasladoP ImpuestoP="002" TipoFactorP="Tasa" TasaOCuotaP="0.160000" BaseP="1089653.476924" ImporteP="174344.556311"/>
           </pago20:TrasladosP>
         </pago20:ImpuestosP>
       </pago20:Pago>

--- a/tests/assets/pagos20-calculator/006.xml
+++ b/tests/assets/pagos20-calculator/006.xml
@@ -20,7 +20,7 @@
         </pago20:DoctoRelacionado>
         <pago20:ImpuestosP>
           <pago20:TrasladosP>
-            <pago20:TrasladoP TasaOCuotaP="0.160000" ImporteP="14.954652" BaseP="93.46658" ImpuestoP="002" TipoFactorP="Tasa"/>
+            <pago20:TrasladoP TasaOCuotaP="0.160000" ImporteP="14.954653" BaseP="93.46658" ImpuestoP="002" TipoFactorP="Tasa"/>
             <pago20:TrasladoP TasaOCuotaP="0.000000" ImporteP="0" BaseP="3.595631" ImpuestoP="002" TipoFactorP="Tasa"/>
             <pago20:TrasladoP BaseP="11.433232" ImpuestoP="002" TipoFactorP="Exento"/>
           </pago20:TrasladosP>
@@ -38,9 +38,9 @@
         </pago20:DoctoRelacionado>
         <pago20:ImpuestosP>
           <pago20:TrasladosP>
-            <pago20:TrasladoP TasaOCuotaP="0.160000" ImporteP="0.460567" BaseP="2.878547" ImpuestoP="002" TipoFactorP="Tasa"/>
-            <pago20:TrasladoP TasaOCuotaP="0.000000" ImporteP="0" BaseP="0.098303" ImpuestoP="002" TipoFactorP="Tasa"/>
-            <pago20:TrasladoP BaseP="0.312582" ImpuestoP="002" TipoFactorP="Exento"/>
+            <pago20:TrasladoP TasaOCuotaP="0.160000" ImporteP="0.460568" BaseP="2.878548" ImpuestoP="002" TipoFactorP="Tasa"/>
+            <pago20:TrasladoP TasaOCuotaP="0.000000" ImporteP="0" BaseP="0.098304" ImpuestoP="002" TipoFactorP="Tasa"/>
+            <pago20:TrasladoP BaseP="0.312583" ImpuestoP="002" TipoFactorP="Exento"/>
           </pago20:TrasladosP>
         </pago20:ImpuestosP>
       </pago20:Pago>
@@ -54,7 +54,7 @@
         </pago20:DoctoRelacionado>
         <pago20:ImpuestosP>
           <pago20:TrasladosP>
-            <pago20:TrasladoP TasaOCuotaP="0.160000" ImporteP="0.031724" BaseP="0.198275" ImpuestoP="002" TipoFactorP="Tasa"/>
+            <pago20:TrasladoP TasaOCuotaP="0.160000" ImporteP="0.031724" BaseP="0.198276" ImpuestoP="002" TipoFactorP="Tasa"/>
           </pago20:TrasladosP>
         </pago20:ImpuestosP>
       </pago20:Pago>

--- a/tests/assets/pagos20-calculator/008.xml
+++ b/tests/assets/pagos20-calculator/008.xml
@@ -51,10 +51,10 @@
         </pago20:DoctoRelacionado>
         <pago20:ImpuestosP>
           <pago20:RetencionesP>
-            <pago20:RetencionP ImpuestoP="002" ImporteP="6005.999997"/>
+            <pago20:RetencionP ImpuestoP="002" ImporteP="6005.999998"/>
           </pago20:RetencionesP>
           <pago20:TrasladosP>
-            <pago20:TrasladoP BaseP="150149.999947" ImpuestoP="002" TipoFactorP="Tasa" TasaOCuotaP="0.160000" ImporteP="24023.999991"/>
+            <pago20:TrasladoP BaseP="150149.999947" ImpuestoP="002" TipoFactorP="Tasa" TasaOCuotaP="0.160000" ImporteP="24023.999992"/>
           </pago20:TrasladosP>
         </pago20:ImpuestosP>
       </pago20:Pago>

--- a/tests/estadosat.php
+++ b/tests/estadosat.php
@@ -1,8 +1,8 @@
 <?php
 
-use \CfdiUtils\ConsultaCfdiSat\WebService;
 use CfdiUtils\Cfdi;
 use CfdiUtils\ConsultaCfdiSat\RequestParameters;
+use CfdiUtils\ConsultaCfdiSat\WebService;
 
 require __DIR__ . '/bootstrap.php';
 

--- a/tests/validate.php
+++ b/tests/validate.php
@@ -9,7 +9,7 @@ use CfdiUtils\Validate\Asserts;
 
 require __DIR__ . '/bootstrap.php';
 
-exit(call_user_func(new class(...$argv) {
+exit(call_user_func(new class (...$argv) {
     /** @var string */
     private $command;
 
@@ -95,23 +95,23 @@ exit(call_user_func(new class(...$argv) {
     {
         $command = basename($this->command);
         echo <<< EOH
-        $command Validates CFDI files
-        Syntax:
-            $command [-h|--help] [-c|--clean] [--no-cache] cfdi.xml ...
-        Arguments:
-            -h, --help   Show this help
-            -c, --clean  Clean CFDI before validation
-            --no-cache   Tell resolver to not use local cache
-            cfdi.xml     Files to check, as many as needed
-        Exit codes:
-            0 - All files were validated with success
-            1 - At least one file contains errors or warnings
-            2 - At least one file produce an exception
+            $command Validates CFDI files
+            Syntax:
+                $command [-h|--help] [-c|--clean] [--no-cache] cfdi.xml ...
+            Arguments:
+                -h, --help   Show this help
+                -c, --clean  Clean CFDI before validation
+                --no-cache   Tell resolver to not use local cache
+                cfdi.xml     Files to check, as many as needed
+            Exit codes:
+                0 - All files were validated with success
+                1 - At least one file contains errors or warnings
+                2 - At least one file produce an exception
 
-        WARNING: This program can change at any time! Do not depend on this file or its results!
+            WARNING: This program can change at any time! Do not depend on this file or its results!
 
 
-        EOH;
+            EOH;
     }
 
     private function printAsserts(Asserts $asserts): bool


### PR DESCRIPTION
Fix calculator for complement *Pagos 2.0*.
For attributes `BaseP` and `ImporteP` the value was truncated. Now, the value has to be rounded.
Some vendors communicate this change, such as Finkok.

Improve calculator with new getter and setter for `paymentTaxesPrecision` and `currencies`.

Update code style as other PhpCfdi projects.

Set up PHPStan paths on configuration file.