### PR TITLE
Deprecate Crp20277Fixer & fix build (version 2.28.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -43,7 +43,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -84,7 +84,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: soap, intl, xsl, fileinfo, bcmath
           coverage: none
           tools: composer:v2, phpstan

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,11 @@
 - Remove classes `CfdiUtils\Elements\Cfdi33\Helpers\SumasConceptosWriter` and `CfdiUtils\Elements\Cfdi40\Helpers\SumasConceptosWriter`.
 - Merge methods from `\CfdiUtils\Nodes\NodeHasValueInterface` into `\CfdiUtils\Nodes\NodeInterface`.
 - Remove deprecated constant `CfdiUtils\Retenciones\Retenciones::RET_NAMESPACE`.
+- Remove deprecated class `CfdiUtils\Utils\Crp20277Fixer`.
+
+## Version 2.28.0 2024-01-17
+
+Deprecate `CfdiUtils\Utils\Crp20277Fixer` since SAT changed the rule `CRP20277`.
 
 ## Version 2.27.1 2024-01-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Remove deprecated constant `CfdiUtils\Retenciones\Retenciones::RET_NAMESPACE`.
 - Remove deprecated class `CfdiUtils\Utils\Crp20277Fixer`.
 
-## Version 2.28.0 2024-01-17
+## Version 2.28.0 2024-01-22
 
 - Deprecate `CfdiUtils\Utils\Crp20277Fixer` since SAT changed the rule `CRP20277`.
 - Fix code style (use same case for `XsltProcessor`).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,7 +35,8 @@
 
 ## Version 2.28.0 2024-01-17
 
-Deprecate `CfdiUtils\Utils\Crp20277Fixer` since SAT changed the rule `CRP20277`.
+- Deprecate `CfdiUtils\Utils\Crp20277Fixer` since SAT changed the rule `CRP20277`.
+- Fix code style (use same case for `XsltProcessor`).
 
 ## Version 2.27.1 2024-01-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 - Deprecate `CfdiUtils\Utils\Crp20277Fixer` since SAT changed the rule `CRP20277`.
 - Fix code style (use same case for `XsltProcessor`).
+- Run GitHub jobs using PHP 8.3.
 
 ## Version 2.27.1 2024-01-12
 

--- a/src/CfdiUtils/CadenaOrigen/GenkgoXslBuilder.php
+++ b/src/CfdiUtils/CadenaOrigen/GenkgoXslBuilder.php
@@ -18,7 +18,7 @@ class GenkgoXslBuilder extends DOMBuilder
 
     protected function transform(DOMDocument $xml, DOMDocument $xsl): string
     {
-        $xslt = new XSLTProcessor(new NullCache());
+        $xslt = new XsltProcessor(new NullCache());
         $xslt->importStyleSheet($xsl);
 
         try {

--- a/src/CfdiUtils/Utils/Crp20277Fixer.php
+++ b/src/CfdiUtils/Utils/Crp20277Fixer.php
@@ -18,7 +18,13 @@ use CfdiUtils\Nodes\NodeInterface;
  *   El campo EquivalenciaDR debe contener el valor "1.0000000000".
  * Esta regla cambia lo especificado en la regla CRP20238.
  *
+ * Deprecación:
+ * El código de error cambió el 2024-01-16 a:
+ *   El valor de EquivalenciaDR para la fórmula del cálculo del margen de variación debe ser “1.0000000000”.
+ * Por lo tanto, no es necesario hacer el cambio de valores en el CFDI.
+ *
  * @see http://omawww.sat.gob.mx/tramitesyservicios/Paginas/recepcion_de_pagos.htm
+ * @deprecated 2.28.0 No es necesario mantener esta clase y será removida en una nueva versión mayor.
  */
 final class Crp20277Fixer
 {


### PR DESCRIPTION
- Deprecate `CfdiUtils\Utils\Crp20277Fixer` since SAT changed the rule `CRP20277`.
- Fix code style (use same case for `XsltProcessor`).
- Run GitHub jobs using PHP 8.3.