### PR TITLE
indicar que las constantes son del global namespace

### DIFF
--- a/src/CfdiUtils/ConsultaCfdiSat/WebService.php
+++ b/src/CfdiUtils/ConsultaCfdiSat/WebService.php
@@ -58,9 +58,9 @@ class WebService
         $soapOptions = [
             'location' => $config->getServiceUrl(),
             'uri' => 'http://tempuri.org/',
-            'style' => SOAP_RPC,
-            'use' => SOAP_LITERAL,
-            'soap_version' => SOAP_1_1,
+            'style' => \SOAP_RPC,
+            'use' => \SOAP_LITERAL,
+            'soap_version' => \SOAP_1_1,
             'exceptions' => 1,
             'stream_context' => stream_context_create([
                 'ssl' => [


### PR DESCRIPTION
Por alguna razón, en producción me esta mandando el error: Undefined constant "CfdiUtils\ConsultaCfdiSat\SOAP_RPC"

PHP busca las constantes en ese namespace en lugar del global.

