### PR TITLE
Maintenance 2025-02-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,10 +146,6 @@ jobs:
           git clone --depth 1 https://github.com/phpcfdi/resources-sat-xml resources-sat-xml-cloned
           mv resources-sat-xml-cloned/resources build/resources
           rm -r -f resources-sat-xml-cloned
-      - name: Remove genkgo/xsl on PHP 8.3
-        if: matrix.php-version == '8.3'
-        run: |
-          composer remove genkgo/xsl --dev --no-interaction --no-progress --no-update
       - name: Install project dependencies
         run: |
           composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
@@ -198,10 +194,6 @@ jobs:
           git clone --depth 1 https://github.com/phpcfdi/resources-sat-xml resources-sat-xml-cloned
           mv resources-sat-xml-cloned/resources build/resources
           rm -r -f resources-sat-xml-cloned
-      - name: Remove genkgo/xsl on PHP 8.3
-        if: matrix.php-version == '8.3'
-        run: |
-          composer remove genkgo/xsl --dev --no-interaction --no-progress --no-update
       - name: Install project dependencies
         run: |
           composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 2024 Carlos C Soto https://eclipxe.com.mx/
+Copyright (c) 2016 - 2025 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ See <https://www.php.net/supported-versions.php> for more details.
 | 2.20.1    | 7.3, 7.4, 8.0, 8.1           | 2022-03-08 |
 | 2.23.5    | 7.3, 7.4, 8.0, 8.1, 8.2, 8.3 | 2023-05-26 |
 
+**About PHP 8.4**: Version 2.x is *almost* compatible with PHP 8.4.
+It shows *deprecation errors* which require a new mayor version to fix it.
+Version 2.30.0 includes a constraint to avoid install this library on PHP 8.4.
+Version 3.x will drop compatibility with unmaintained PHP versions and will include compatibility with PHP 8.4.
+
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTING][] for details

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "optimize-autoloader": true
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.3 <8.4",
         "ext-libxml": "*",
         "ext-dom": "*",
         "ext-xsl": "*",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpstan/phpstan": "^1.5"
+        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,15 @@
 - Remove deprecated constant `CfdiUtils\Retenciones\Retenciones::RET_NAMESPACE`.
 - Remove deprecated class `CfdiUtils\Utils\Crp20277Fixer`.
 
+## Version 2.30.0 2024-06-18
+
+This is a maintenance release to fix continuous integration.
+
+- Update license year to 2025.
+- Upgrade to PHPStan 2.1 and fix/ignore new issues.
+- Avoid PHP 8.4 due deprecation messages.
+- Remove code to avoid testing genkgo/xsl on PHP 8.3.
+
 ## Version 2.29.0 2024-06-18
 
 Add `CfdiUtils\Elements\CartaPorte31` *Elements* to work with "Carta Porte 3.1".

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 parameters:
   level: 5
   inferPrivatePropertyTypeFromConstructor: true
+  treatPhpDocTypesAsCertain: false
   paths:
     - src/
     - tests/

--- a/src/CfdiUtils/CadenaOrigen/GenkgoXslBuilder.php
+++ b/src/CfdiUtils/CadenaOrigen/GenkgoXslBuilder.php
@@ -22,12 +22,11 @@ class GenkgoXslBuilder extends DOMBuilder
         $xslt->importStyleSheet($xsl);
 
         try {
-            /** @var string|null|false $transform */
             $transform = $xslt->transformToXML($xml);
         } catch (TransformationException $exception) {
             throw new XsltBuildException('Error while transforming the xslt content', 0, $exception);
         }
-        if (null === $transform || false === $transform) {
+        if (null === $transform) {
             throw $this->createLibXmlErrorOrMessage('Error while transforming the xslt content');
         }
 

--- a/src/CfdiUtils/Cleaner/Cleaner.php
+++ b/src/CfdiUtils/Cleaner/Cleaner.php
@@ -334,12 +334,7 @@ class Cleaner
         if (! $xsi) {
             return new DOMNodeList();
         }
-        /** @var DOMNodeList<DOMAttr>|false $nodeList */
-        $nodeList = $this->xpathQuery("//@$xsi:schemaLocation");
-        if (false === $nodeList) {
-            return new DOMNodeList();
-        }
-        return $nodeList;
+        return $this->xpathQuery("//@$xsi:schemaLocation");
     }
 
     /** @return string[] */

--- a/src/CfdiUtils/ConsultaCfdiSat/WebService.php
+++ b/src/CfdiUtils/ConsultaCfdiSat/WebService.php
@@ -106,7 +106,6 @@ class WebService
      */
     protected function doRequestConsulta(string $expression): ?stdClass
     {
-        /** @var int $encoding Override because inspectors does not know that second argument can be NULL */
         $encoding = null;
         return $this->getSoapClient()->__soapCall(
             'Consulta',

--- a/src/CfdiUtils/Nodes/NodeNsDefinitionsMover.php
+++ b/src/CfdiUtils/Nodes/NodeNsDefinitionsMover.php
@@ -54,7 +54,7 @@ class NodeNsDefinitionsMover
 
     protected function moveXmlNs(NodeInterface $child, NodeInterface $root)
     {
-        $prefix = explode(':', $child->name(), 2)[0] ?? '';
+        $prefix = explode(':', $child->name(), 2)[0];
         if ($child->name() === $prefix) {
             return;  // it does not have a prefix
         }

--- a/tests/CfdiUtilsTests/Certificado/CertificateDownloaderHelper.php
+++ b/tests/CfdiUtilsTests/Certificado/CertificateDownloaderHelper.php
@@ -38,10 +38,10 @@ final class CertificateDownloaderHelper implements DownloaderInterface
     {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $source);
-        curl_setopt($ch, CURLOPT_VERBOSE, 0); // set to 1 to debug
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_VERBOSE, false); // set to true to debug
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_HEADER, false);
         $result = (string) curl_exec($ch);
         $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
         curl_close($ch);

--- a/tests/CfdiUtilsTests/CfdiValidator33Test.php
+++ b/tests/CfdiUtilsTests/CfdiValidator33Test.php
@@ -77,7 +77,7 @@ final class CfdiValidator33Test extends TestCase
             'new' => $comprobante['Sello'],
         ]);
         // echo $creator->asXml();
-        $this->assertTrue(false, 'This procedure must not run in real testing');
+        $this->fail('This procedure must not run in real testing');
     }
 
     public function testValidateThrowsExceptionIfEmptyContent()

--- a/tests/CfdiUtilsTests/Nodes/NodesTest.php
+++ b/tests/CfdiUtilsTests/Nodes/NodesTest.php
@@ -77,9 +77,7 @@ final class NodesTest extends TestCase
         $found = $root->searchNode('child');
         $this->assertSame($child, $found);
 
-        if (null !== $found) {
-            $nodes->remove($found);
-        }
+        $nodes->remove($found);
         $this->assertFalse($nodes->exists($child));
     }
 
@@ -109,7 +107,7 @@ final class NodesTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The element index 0 is not a NodeInterface object');
         /** @var NodeInterface $specimen Override type to avoid problems with static analyser */
-        $specimen = new \stdClass();
+        $specimen = new \stdClass(); /** @phpstan-ignore-line */
         $nodes->importFromArray([$specimen]);
     }
 

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLPropertyTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLPropertyTest.php
@@ -29,7 +29,10 @@ final class OpenSSLPropertyTest extends TestCase
         };
 
         $this->expectException(\TypeError::class);
-        /** @noinspection PhpExpressionResultUnusedInspection */
+        /**
+         * @noinspection PhpExpressionResultUnusedInspection
+         * @phpstan-ignore-next-line
+         */
         $object->getOpenSSL();
     }
 
@@ -38,6 +41,7 @@ final class OpenSSLPropertyTest extends TestCase
         $object = new class () {
             use OpenSSLPropertyTrait;
         };
+        /** @phpstan-ignore-next-line */
         $this->assertFalse(is_callable([$object, 'setOpenSSL']), 'setOpenSSL must not be public accesible');
     }
 }

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckInputFileTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckInputFileTest.php
@@ -22,7 +22,7 @@ final class OpenSSLProtectedMethodCheckInputFileTest extends TestCase
     public function testValidInputFile()
     {
         $this->openSSL()->checkInputFile(__FILE__);
-        $this->assertTrue(true, 'No exception thrown');
+        $this->assertTrue(true, 'No exception thrown'); /** @phpstan-ignore-line */
     }
 
     public function testThrowExceptionUsingEmptyFileName()

--- a/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckOutputFileTest.php
+++ b/tests/CfdiUtilsTests/OpenSSL/OpenSSLProtectedMethodCheckOutputFileTest.php
@@ -22,7 +22,7 @@ final class OpenSSLProtectedMethodCheckOutputFileTest extends TestCase
     public function testValidOutputFileNonExistent()
     {
         $this->openSSL()->checkOutputFile(__DIR__ . '/non-existent');
-        $this->assertTrue(true, 'No exception thrown');
+        $this->assertTrue(true, 'No exception thrown'); /** @phpstan-ignore-line */
     }
 
     public function testValidOutputFileZeroSize()
@@ -33,7 +33,7 @@ final class OpenSSLProtectedMethodCheckOutputFileTest extends TestCase
         } finally {
             $tempfile->remove();
         }
-        $this->assertTrue(true, 'No exception thrown');
+        $this->assertTrue(true, 'No exception thrown'); /** @phpstan-ignore-line */
     }
 
     public function testThrowExceptionUsingEmptyFileName()

--- a/tests/CfdiUtilsTests/QuickReader/QuickReaderTest.php
+++ b/tests/CfdiUtilsTests/QuickReader/QuickReaderTest.php
@@ -64,7 +64,6 @@ final class QuickReaderTest extends TestCase
     {
         $foo = new QuickReader('foo');
         $this->assertTrue(is_array($foo())); /** @phpstan-ignore-line */
-
         $xee = $foo->bar->xee;
         $this->assertTrue(is_array($xee('zee')));
         $this->assertTrue(is_array($xee->__invoke('zee')));

--- a/tests/CfdiUtilsTests/QuickReader/QuickReaderTest.php
+++ b/tests/CfdiUtilsTests/QuickReader/QuickReaderTest.php
@@ -63,7 +63,7 @@ final class QuickReaderTest extends TestCase
     public function testAccessInvokeReturnsAnArray()
     {
         $foo = new QuickReader('foo');
-        $this->assertTrue(is_array($foo()));
+        $this->assertTrue(is_array($foo())); /** @phpstan-ignore-line */
 
         $xee = $foo->bar->xee;
         $this->assertTrue(is_array($xee('zee')));
@@ -154,9 +154,8 @@ final class QuickReaderTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage("The attribute 'bar' has a non string value");
-        /** @var string $fakeString */
         $fakeString = new \stdClass();
-        new QuickReader('foo', ['x' => 'y', 'bar' => $fakeString]);
+        new QuickReader('foo', ['x' => 'y', 'bar' => $fakeString]); /** @phpstan-ignore-line */
     }
 
     public function testConstructThrowExceptionOnInvalidChildren()

--- a/tests/CfdiUtilsTests/Validate/DiscovererTest.php
+++ b/tests/CfdiUtilsTests/Validate/DiscovererTest.php
@@ -27,7 +27,7 @@ final class DiscovererTest extends TestCase
         $namespace = __NAMESPACE__ . '\FakeObjects';
         $file = __DIR__ . '/FakeObjects/ImplementationDiscoverableCreateInterface.php';
         $discovered = $discoverer->discoverInFile($namespace, $file);
-        $this->assertNotNull($discoverer);
+        $this->assertNotNull($discovered);
         $this->assertInstanceOf(ValidatorInterface::class, $discovered);
     }
 }


### PR DESCRIPTION
Update license year to 2025.
Upgrade to PHPStan 2.1 and fix/ignore new issues.
Avoid PHP 8.4 due deprecation messages.
Remove code to avoid testing genkgo/xsl on PHP 8.3.