### PR TITLE
Write TasaOCuotaP only when TipoFactorP is not Exento (version 3.0.1)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.72.0" installed="3.72.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.12.0" installed="3.12.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.12.0" installed="3.12.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^2.1.8" installed="2.1.8" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.75.0" installed="3.75.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.12.2" installed="3.12.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.12.2" installed="3.12.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.14" installed="2.1.14" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@
 Add `S A P I DE CV` to `RegimenCapitalRemover`.
 This should be an error from SAT when creates the certificate 00001000000710061506, but we have deal with it.
 
+Fix a bug when write *pagos* summary.
+On the taxes information it was writing `TasaOCuotaP` when `TipoFactorP` is `Exento`.
+It now does not write that attribute as in `ImporteP`.
+
 ## Version 3.0.0 2025-03-18
 
 This is a major release primary for compatibility to PHP 8.4.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Fix/improve `ElementsMaker` standard.
 - Remove code to build CFDI 3.3.
 
+## Version 3.0.1 2025-05-01
+
+Add `S A P I DE CV` to `RegimenCapitalRemover`.
+This should be an error from SAT when creates the certificate 00001000000710061506, but we have deal with it.
+
 ## Version 3.0.0 2025-03-18
 
 This is a major release primary for compatibility to PHP 8.4.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,9 +12,10 @@
 Add `S A P I DE CV` to `RegimenCapitalRemover`.
 This should be an error from SAT when creates the certificate 00001000000710061506, but we have deal with it.
 
-Fix a bug when write *pagos* summary.
-On the taxes information it was writing `TasaOCuotaP` when `TipoFactorP` is `Exento`.
+Fix a bug when write *Pagos* taxes summary.
+It was writing `TasaOCuotaP` when `TipoFactorP` is `Exento`.
 It now does not write that attribute as in `ImporteP`.
+Thanks `@jiagbrody` (discord) for noticing this issue.
 
 ## Version 3.0.0 2025-03-18
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>

--- a/src/CfdiUtils/SumasPagos20/PagosWriter.php
+++ b/src/CfdiUtils/SumasPagos20/PagosWriter.php
@@ -90,7 +90,7 @@ final class PagosWriter
                 $trasladosElement->addTrasladoP([
                     'ImpuestoP' => $traslado->getImpuesto(),
                     'TipoFactorP' => $traslado->getTipoFactor(),
-                    'TasaOCuotaP' => $traslado->getTasaCuota(),
+                    'TasaOCuotaP' => ('Exento' === $traslado->getTipoFactor()) ? null : $traslado->getTasaCuota(),
                     'BaseP' => $traslado->getBase(),
                     'ImporteP' => ('Exento' === $traslado->getTipoFactor()) ? null : $traslado->getImporte(),
                 ]);

--- a/src/CfdiUtils/Utils/RegimenCapitalRemover.php
+++ b/src/CfdiUtils/Utils/RegimenCapitalRemover.php
@@ -104,6 +104,7 @@ final class RegimenCapitalRemover
         'SAB DE CV',
         'SAB',
         'SAPI DE CV',
+        'S A P I DE CV',
         'SAPI DE CV,SOFOM,ENR',
         'SAPI',
         'SAS DE CV',

--- a/tests/CfdiUtilsTests/SumasPagos20/PagosWriterTest.php
+++ b/tests/CfdiUtilsTests/SumasPagos20/PagosWriterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CfdiUtilsTests\SumasPagos20;
+
+use CfdiUtils\Elements\Pagos20\Pagos as ElementPagos20;
+use CfdiUtils\SumasPagos20\Calculator;
+use CfdiUtils\SumasPagos20\PagosWriter;
+use CfdiUtilsTests\TestCase;
+
+final class PagosWriterTest extends TestCase
+{
+    public function testWritePagoWithOnlyOneExento(): void
+    {
+        $pagos = new ElementPagos20();
+
+        $pago = $pagos->addPago([
+            'FechaPago' => '2025-06-24',
+            'FormaDePagoP' => '03',
+            'MonedaP' => 'MXN',
+            'TipoCambioP' => '1',
+            'Monto' => '10.00',
+        ]);
+
+        $pago->addDoctoRelacionado([
+            'IdDocumento' => '00000000-1111-2222-3333-00000000000A',
+            'MonedaDR' => 'MXN',
+            'EquivalenciaDR' => '1',
+            'NumParcialidad' => '1',
+            'ImpSaldoAnt' => '4500.00',
+            'ImpPagado' => '10.00',
+            'ImpSaldoInsoluto' => '4490.00',
+            'ObjetoImpDR' => '02',
+        ])->getImpuestosDR()->getTrasladosDR()->addTrasladoDR([
+            'BaseDR' => '10.00',
+            'ImpuestoDR' => '002',
+            'TipoFactorDR' => 'Exento',
+        ]);
+
+        $calculator = new Calculator(2);
+        $result = $calculator->calculate($pagos);
+
+        $writer = new PagosWriter($pagos);
+        $writer->writePago($pago, $result->getPago(0));
+
+        $traslado = $pagos->searchNode('pago20:Pago', 'pago20:ImpuestosP', 'pago20:TrasladosP', 'pago20:TrasladoP');
+        $this->assertFalse(isset($traslado['TasaOCuotaP']));
+        $this->assertFalse(isset($traslado['ImporteP']));
+        $this->assertSame('002', $traslado['ImpuestoP']);
+        $this->assertSame('10.00', $traslado['BaseP']);
+    }
+}

--- a/tests/CfdiUtilsTests/Utils/RegimenCapitalRemoverTest.php
+++ b/tests/CfdiUtilsTests/Utils/RegimenCapitalRemoverTest.php
@@ -38,4 +38,13 @@ final class RegimenCapitalRemoverTest extends TestCase
         $remover = RegimenCapitalRemover::createDefault();
         $this->assertSame($expected, $remover->remove($fullname));
     }
+
+    public function testRemoveSapiDeCv(): void
+    {
+        // There are CSD (like 00001000000710061506) with "EMPRESA S A P I DE CV"
+        $fullname = 'EMPRESA S A P I DE CV';
+        $expected = 'EMPRESA';
+        $remover = RegimenCapitalRemover::createDefault();
+        $this->assertSame($expected, $remover->remove($fullname));
+    }
 }


### PR DESCRIPTION
Add `S A P I DE CV` to `RegimenCapitalRemover`.
This should be an error from SAT when creates the certificate 00001000000710061506, but we have deal with it.

Fix a bug when write *pagos* summary.
On the taxes information it was writing `TasaOCuotaP` when `TipoFactorP` is `Exento`.
It now does not write that attribute as in `ImporteP`.
