### PR TITLE
Fix: remove dotted regimen suffix ( CAFETALERA S.P.R. DE R.L. | CAFET…

### DIFF
--- a/src/CfdiUtils/Certificado/Certificado.php
+++ b/src/CfdiUtils/Certificado/Certificado.php
@@ -173,8 +173,11 @@ class Certificado
     public function getNameWithoutRegimenCapitalSuffix(): string
     {
         if (null === $this->nameWithoutRegimenCapitalSuffix) {
-            $remover = RegimenCapitalRemover::createDefault();
-            $this->nameWithoutRegimenCapitalSuffix = $remover->remove($this->name);
+             $remover = RegimenCapitalRemover::createDefault();
+-            $this->nameWithoutRegimenCapitalSuffix = $remover->remove($this->name);
++            $normalized = preg_replace('/(?<=\b[A-Z])\./', '', $this->name);
++            $this->nameWithoutRegimenCapitalSuffix = $remover->remove($normalized);
+
         }
 
         return $this->nameWithoutRegimenCapitalSuffix;


### PR DESCRIPTION
ste PR corrige un caso donde el RegimenCapitalRemover no elimina sufijos cuando vienen con puntos intermedios, como:
S.P.R. DE R.L.
Caso Real que encontré en un certificado:
CONCORDIA SUPERIOR COMPAÑIA CAFETALERA S.P.R. DE R.L.

### Ejemplos de normalización

| Entrada (del certificado) | Normalizado | Sufijo removido |
|---|---|---|
| `EMPRESA X S.A. DE C.V.` | `EMPRESA X SA DE CV` | ✅ `SA DE CV` |
| `CAFETALERA S.P.R. DE R.L.` | `CAFETALERA SPR DE RL` | ✅ `SPR DE RL` |
| `COOPERATIVA S.C. DE R.L. DE C.V.` | `COOPERATIVA SC DE RL DE CV` | ✅ `SC DE RL DE CV` |
| `EMPRESA NORMAL SA DE CV` | `EMPRESA NORMAL SA DE CV` | ✅ sin cambios, ya funciona |
| `SOCIEDAD COOPERATIVA` | `SOCIEDAD COOPERATIVA` | ✅ sin cambios, no hay puntos |

## Ventajas de este enfoque

1. **No modifica `RegimenCapitalRemover`** — la lista de sufijos permanece intacta
2. **No duplica entradas** — no necesitamos agregar variantes con puntos
3. **Es retrocompatible** — nombres sin puntos no se ven afectados
4. **Un solo punto de cambio** — la normalización ocurre en el método que consume el nombre
<img width="375" height="412" alt="Captura de pantalla 2026-05-29 130558" src="https://github.com/user-attachments/assets/a15d079c-f6a0-4160-bcaa-d47cc5831551" />

